### PR TITLE
fix freezing gui performance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PySide6==6.7.1
+PySide6==6.7.2
 pyinstaller==6.8.0

--- a/src/dds_data.py
+++ b/src/dds_data.py
@@ -30,7 +30,7 @@ class DataEndpoint:
         self.endpoint: DcpsEndpoint = endpoint
         self.entity_type: EntityType = entity_type
         self.participant = None
-        self.missmatches : Dict[str, List[dds_qos_policy_id]]= {}
+        self.mismatches : Dict[str, List[dds_qos_policy_id]]= {}
 
     def isReader(self):
         return self.entity_type == EntityType.READER
@@ -61,18 +61,18 @@ class DataTopic:
 
     def remove_endpoint(self, endpointKey: str):
         if endpointKey in self.reader_endpoints:
-            for mimKey in self.reader_endpoints[endpointKey].missmatches:
+            for mimKey in self.reader_endpoints[endpointKey].mismatches:
                 if mimKey in self.writer_endpoints:
-                    if endpointKey in self.writer_endpoints[mimKey].missmatches:
-                        del self.writer_endpoints[mimKey].missmatches[endpointKey]
+                    if endpointKey in self.writer_endpoints[mimKey].mismatches:
+                        del self.writer_endpoints[mimKey].mismatches[endpointKey]
 
             del self.reader_endpoints[endpointKey]
     
         if endpointKey in self.writer_endpoints:
-            for mimKey in self.writer_endpoints[endpointKey].missmatches:
+            for mimKey in self.writer_endpoints[endpointKey].mismatches:
                 if mimKey in self.reader_endpoints:
-                    if endpointKey in self.reader_endpoints[mimKey].missmatches:
-                        del self.reader_endpoints[mimKey].missmatches[endpointKey]
+                    if endpointKey in self.reader_endpoints[mimKey].mismatches:
+                        del self.reader_endpoints[mimKey].mismatches[endpointKey]
 
             del self.writer_endpoints[endpointKey]
 
@@ -101,17 +101,17 @@ class DataTopic:
                 mismatches = qos_match(endpoint_to_check.endpoint, data_endpoint.endpoint)
 
             if len(mismatches) > 0:
-                data_endpoint.missmatches[str(endpoint_to_check.endpoint.key)] = mismatches
-                endpoint_to_check.missmatches[str(data_endpoint.endpoint.key)] = mismatches
+                data_endpoint.mismatches[str(endpoint_to_check.endpoint.key)] = mismatches
+                endpoint_to_check.mismatches[str(data_endpoint.endpoint.key)] = mismatches
 
     def get_mismatches(self) -> List[str]:
         mism_endp_keys: List[str] = []
         for endpKey in self.reader_endpoints.keys():
-            if len(self.reader_endpoints[endpKey].missmatches):
-                mism_endp_keys += self.reader_endpoints[endpKey].missmatches.keys()
+            if len(self.reader_endpoints[endpKey].mismatches):
+                mism_endp_keys += self.reader_endpoints[endpKey].mismatches.keys()
         for endpKey in self.writer_endpoints.keys():
-            if len(self.writer_endpoints[endpKey].missmatches):
-                mism_endp_keys += self.writer_endpoints[endpKey].missmatches.keys()
+            if len(self.writer_endpoints[endpKey].mismatches):
+                mism_endp_keys += self.writer_endpoints[endpKey].mismatches.keys()
 
         return list(dict.fromkeys(mism_endp_keys))
 

--- a/src/dds_data.py
+++ b/src/dds_data.py
@@ -10,208 +10,333 @@
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
 """
 
-from PySide6.QtCore import QObject, Signal, Slot
+from PySide6.QtCore import QObject, Signal, Slot, QThread, Qt
 from cyclonedds.builtin import DcpsEndpoint, DcpsParticipant
 import threading
 import logging
+import time
+import copy
+from queue import Queue
+from typing import Dict, List
+import gc
 
 from dds_service import builtin_observer
-from dds_qos import qos_match
+from dds_qos import qos_match, dds_qos_policy_id
 from utils import singleton, EntityType
 
+
+class DataEndpoint:
+    def __init__(self, endpoint: DcpsEndpoint, entity_type) -> None:
+        self.endpoint: DcpsEndpoint = endpoint
+        self.entity_type: EntityType = entity_type
+        self.participant = None
+        self.missmatches : Dict[str, List[dds_qos_policy_id]]= {}
+
+    def isReader(self):
+        return self.entity_type == EntityType.READER
+
+    def isWriter(self):
+        return self.entity_type == EntityType.WRITER
+
+    def link_participant(self, participant: DcpsParticipant):
+        if str(self.endpoint.participant_key) == str(participant.key):
+            self.participant = participant
+
+
+class DataTopic:
+    def __init__(self, name) -> None:
+        self.name = name
+        self.reader_endpoints: Dict[str, DataEndpoint] = {}
+        self.writer_endpoints: Dict[str, DataEndpoint] = {}
+
+    def add_endpoint(self, endpoint: DataEndpoint):
+        if endpoint.isReader():
+            if str(endpoint.endpoint.key) not in self.reader_endpoints:
+                self.reader_endpoints[str(endpoint.endpoint.key)] = endpoint
+        else:
+            if str(endpoint.endpoint.key) not in self.writer_endpoints:
+                self.writer_endpoints[str(endpoint.endpoint.key)] = endpoint
+
+        self.check_qos_mismatch(endpoint)
+
+    def remove_endpoint(self, endpointKey: str):
+        if endpointKey in self.reader_endpoints:
+            for mimKey in self.reader_endpoints[endpointKey].missmatches:
+                if mimKey in self.writer_endpoints:
+                    if endpointKey in self.writer_endpoints[mimKey].missmatches:
+                        del self.writer_endpoints[mimKey].missmatches[endpointKey]
+
+            del self.reader_endpoints[endpointKey]
+    
+        if endpointKey in self.writer_endpoints:
+            for mimKey in self.writer_endpoints[endpointKey].missmatches:
+                if mimKey in self.reader_endpoints:
+                    if endpointKey in self.reader_endpoints[mimKey].missmatches:
+                        del self.reader_endpoints[mimKey].missmatches[endpointKey]
+
+            del self.writer_endpoints[endpointKey]
+
+    def link_participant(self, participant: DcpsParticipant):
+        for reader_key in self.reader_endpoints.keys():
+            self.reader_endpoints[reader_key].link_participant(participant)
+        for writer_key in self.writer_endpoints.keys():
+            self.writer_endpoints[writer_key].link_participant(participant)
+
+    def hasEndpoints(self) -> bool:
+        return len(self.reader_endpoints) > 0 or len(self.writer_endpoints) > 0
+
+    def check_qos_mismatch(self, data_endpoint: DataEndpoint):
+
+        endpoints_to_check = self.reader_endpoints
+        if data_endpoint.isReader():
+            endpoints_to_check = self.writer_endpoints
+
+        for endpKey in endpoints_to_check.keys():
+            endpoint_to_check = endpoints_to_check[endpKey]
+
+            mismatches: List[dds_qos_policy_id] = []
+            if data_endpoint.isReader():
+                mismatches = qos_match(data_endpoint.endpoint, endpoint_to_check.endpoint)
+            else:
+                mismatches = qos_match(endpoint_to_check.endpoint, data_endpoint.endpoint)
+
+            if len(mismatches) > 0:
+                data_endpoint.missmatches[str(endpoint_to_check.endpoint.key)] = mismatches
+                endpoint_to_check.missmatches[str(data_endpoint.endpoint.key)] = mismatches
+
+    def get_mismatches(self) -> List[str]:
+        mism_endp_keys: List[str] = []
+        for endpKey in self.reader_endpoints.keys():
+            if len(self.reader_endpoints[endpKey].missmatches):
+                mism_endp_keys += self.reader_endpoints[endpKey].missmatches.keys()
+        for endpKey in self.writer_endpoints.keys():
+            if len(self.writer_endpoints[endpKey].missmatches):
+                mism_endp_keys += self.writer_endpoints[endpKey].missmatches.keys()
+
+        return list(dict.fromkeys(mism_endp_keys))
+
+class DataDomain:
+    def __init__(self, domain_id: int, queue) -> None:
+        self.domain_id = domain_id
+        self.topics: Dict[str, DataTopic] = {}
+        self.endpointToTopic = {} # shortcut for deletion where only endp key is available
+        self.participants = {}
+        self.obs_running = [True]
+
+        self.obs_thread = threading.Thread(target=builtin_observer, args=(domain_id, queue, self.obs_running))
+
+        self.obs_thread.start()
+
+    def add_participant(self, participant: DcpsParticipant):
+        self.participants[str(participant.key)] = participant
+        for topic in self.topics.keys():
+            self.topics[topic].link_participant(participant)
+
+    def add_endpoint(self, dataEndpoint: DataEndpoint):
+        self.endpointToTopic[str(dataEndpoint.endpoint.key)] = str(dataEndpoint.endpoint.topic_name)
+        if str(dataEndpoint.endpoint.topic_name) not in self.topics:
+            self.topics[str(dataEndpoint.endpoint.topic_name)] = DataTopic(str(dataEndpoint.endpoint.topic_name))
+
+        if str(dataEndpoint.endpoint.participant_key) in self.participants:
+            dataEndpoint.link_participant(self.participants[str(dataEndpoint.endpoint.participant_key)])
+
+        self.topics[str(dataEndpoint.endpoint.topic_name)].add_endpoint(dataEndpoint)
+
+    def remove_endpoint(self, endpoint_key: str):
+        if endpoint_key in self.endpointToTopic:
+            topicName = self.endpointToTopic[endpoint_key]
+            if topicName in self.topics:
+                self.topics[topicName].remove_endpoint(endpoint_key)
+                del self.endpointToTopic[endpoint_key]
+
+                if not self.topics[topicName].hasEndpoints():
+                    del self.topics[topicName]
+
+    def remove_participant(self, key: str):
+        if key in self.participants:
+            del self.participants[key]
+
+    def hash_topic(self, topicName: str) -> bool:
+        return topicName in self.topics
+
+    def get_topic_name(self, endpointKey: str) -> bool:
+        if endpointKey in self.endpointToTopic:
+            return self.endpointToTopic[endpointKey]
+        return ""
+
+    def getEndpoints(self, topicName: str, entity_type: EntityType):
+        if topicName in self.topics:
+            if entity_type == EntityType.READER:
+                return self.topics[topicName].reader_endpoints
+            else:
+                return self.topics[topicName].writer_endpoints
+        return {}
+
+    def __del__(self):
+        self.obs_running[0] = False
+        self.obs_thread.join()
+
+class BuiltInReceiver(QObject):
+
+    newParticipantSignal = Signal(int, DcpsParticipant)
+    newEndpointSignal = Signal(int, DcpsParticipant, EntityType)
+    removeParticipantSignal = Signal(int, DcpsParticipant)
+    removeEndpointSignal = Signal(int, DcpsParticipant)
+
+    def __init__(self, queue):
+        super().__init__()
+        self.queue = queue
+        self.running = True
+
+    def run(self):
+        logging.info(f"Running BuiltInReceiver ... (thread: {QThread.currentThread()})")
+
+        while self.running:
+            time.sleep(2)
+
+            while self.running:
+                if self.queue.empty():
+                    break
+
+                item = self.queue.get()
+                if item is None:
+                    break
+
+                for (domain_id, participant) in item.new_participants:
+                    self.newParticipantSignal.emit(domain_id, participant)
+
+                for (domain_id, participant) in item.remove_participants:
+                    self.removeParticipantSignal.emit(domain_id, participant)
+
+                for (domain_id, endpoint, entity_type) in item.new_endpoints:
+                    self.newEndpointSignal.emit(domain_id, endpoint, entity_type)
+
+                for (domain_id, endpoint) in item.remove_endpoints:
+                    self.removeEndpointSignal.emit(domain_id, endpoint)
+
+        logging.info("Running BuiltInReceiver ... DONE")
+
+    def stop(self):
+        self.running = False
 
 @singleton
 class DdsData(QObject):
 
     # domain observer threads
     observer_threads = {}
-    mutex = threading.Lock()
 
     # signals and slots
     new_topic_signal = Signal(int, str)
     remove_topic_signal = Signal(int, str)
     new_domain_signal = Signal(int)
     removed_domain_signal = Signal(int)
-    new_endpoint_signal = Signal(int, DcpsEndpoint, EntityType)
+    new_endpoint_signal = Signal(str, int, DataEndpoint)
     removed_endpoint_signal = Signal(int, str)
     new_participant_signal = Signal(int, DcpsParticipant)
     removed_participant_signal = Signal(int, str)
-    new_mismatch_signal = Signal(int, str, str, list, str)
-    no_more_mismatch_in_topic_signal = Signal(int, str)
 
-    # data store
-    domains = []
-    endpoints = {}
-    participants = {}
-    mismatches = {}
+    no_more_mismatch_in_topic_signal = Signal(int, str)
+    publish_mismatch_signal = Signal(int, str, list)
+
+    the_domains: Dict[int, DataDomain] = {}
+
+    queue = Queue()
+
+    def __init__(self):
+        super().__init__()
+        logging.debug("Construct DdsData")
+        self.receiverThread: QThread = QThread()
+        self.receiver: BuiltInReceiver = BuiltInReceiver(self.queue)
+        self.receiver.moveToThread(self.receiverThread)
+        self.receiver.newParticipantSignal.connect(self.add_domain_participant, Qt.ConnectionType.QueuedConnection)
+        self.receiver.newEndpointSignal.connect(self.add_endpoint, Qt.ConnectionType.QueuedConnection)
+        self.receiver.removeParticipantSignal.connect(self.remove_domain_participant, Qt.ConnectionType.QueuedConnection)
+        self.receiver.removeEndpointSignal.connect(self.remove_endpoint, Qt.ConnectionType.QueuedConnection)
+        self.receiverThread.started.connect(self.receiver.run)
+        self.receiverThread.finished.connect(self.receiver.deleteLater)
+        self.receiverThread.start()
 
     def join_observer(self):
-        for obs_key in self.observer_threads.keys():
-            obs, obs_running = self.observer_threads[obs_key]
-            obs_running[0] = False
-            obs.join()
+        self.receiver.stop()
+        self.receiverThread.quit()
+        self.receiverThread.wait()
+        self.the_domains.clear()
+        gc.collect()
 
     def add_domain(self, domain_id: int):
-        with self.mutex:
-            if domain_id in self.domains:
-                return
-
-            self.domains.append(domain_id)
-            obs_running = [True]
-
-            obs_thread = threading.Thread(target=builtin_observer, args=(domain_id, self, obs_running))
-            obs_thread.start()
-            self.observer_threads[domain_id] = (obs_thread, obs_running)
-            self.new_domain_signal.emit(domain_id)
+        if domain_id in self.the_domains:
+            return
+        self.the_domains[domain_id] = DataDomain(domain_id, self.queue)
+        self.new_domain_signal.emit(domain_id)
 
     @Slot(int)
     def remove_domain(self, domain_id: int):
-        with self.mutex:
-            if domain_id in self.domains:
-                self.domains.remove(domain_id)
+        if domain_id in self.the_domains:
+            del self.the_domains[domain_id]
+            gc.collect()
 
-            if domain_id in self.observer_threads.keys():
-                obs, obs_running = self.observer_threads[domain_id]
-                obs_running[0] = False
-                obs.join()
-                del self.observer_threads[domain_id]
+        self.removed_domain_signal.emit(domain_id)
 
-            if domain_id in self.endpoints.keys():
-                del self.endpoints[domain_id]
-
-            self.removed_domain_signal.emit(domain_id)
 
     @Slot(int, DcpsParticipant)
     def add_domain_participant(self, domain_id: int, participant: DcpsParticipant):
-        with self.mutex:
-            logging.info(f"Add domain participant {str(participant.key)}")
-            if domain_id in self.participants.keys():
-                self.participants[domain_id].append(participant)
-            else:
-                self.participants[domain_id] = [participant]
+        #logging.debug(f"Add domain participant {str(participant.key)}")
 
-            self.new_participant_signal.emit(domain_id, participant)
+        if domain_id in self.the_domains:
+            self.the_domains[domain_id].add_participant(participant)
+
+        self.new_participant_signal.emit(domain_id, participant)
 
     @Slot(int, DcpsParticipant)
     def remove_domain_participant(self, domain_id: int, participant: DcpsParticipant):
-        with self.mutex:
-            if domain_id in self.participants.keys():
-                available = -1
-                for idx, participant_iter in enumerate(self.participants[domain_id]):
-                    if participant.key == participant_iter.key:
-                        available = idx
-                        break
-
-                if available != -1:
-                    logging.info(f"Remove domain participant {str(participant.key)}")
-                    del self.participants[domain_id][idx]
-                    self.removed_participant_signal.emit(domain_id, str(participant.key))
-
-    def check_qos_mismatches(self, domain_id):
-        """Check the given domain if there are reader and writer
-        with a qos mismatch. A signal is emitted on mismatch."""
-
-        if domain_id in self.endpoints.keys():
-            if domain_id in self.mismatches:
-                del self.mismatches[domain_id]
-            for (entity_type, endpoint) in self.endpoints[domain_id]:
-                for (entity_type_iter, endpoint_iter) in self.endpoints[domain_id]:
-                    if (endpoint.topic_name == endpoint_iter.topic_name and
-                            endpoint.key != endpoint_iter.key and
-                            entity_type_iter != entity_type):
-
-                        if entity_type.READER and entity_type_iter.WRITER:
-                            mismatches = qos_match(endpoint, endpoint_iter)
-                        else:
-                            mismatches = qos_match(endpoint_iter, endpoint)
-
-                        if len(mismatches) > 0:
-                            if domain_id not in self.mismatches.keys():
-                                self.mismatches[domain_id] = {}
-
-                            if str(endpoint.key) not in self.mismatches[domain_id]:
-                                self.mismatches[domain_id][str(endpoint.key)] = {}
-
-                            self.mismatches[domain_id][str(endpoint.key)][endpoint_iter.key] = mismatches
-                            self.new_mismatch_signal.emit(domain_id, endpoint.topic_name, str(endpoint.key), mismatches, str(endpoint_iter.key))
+        if domain_id in self.the_domains:
+            self.the_domains[domain_id].remove_participant(str(participant.key))
+            self.removed_participant_signal.emit(domain_id, str(participant.key))
 
     @Slot(int, DcpsEndpoint, EntityType)
     def add_endpoint(self, domain_id: int, endpoint: DcpsEndpoint, entity_type: EntityType):
-        with self.mutex:
-            # add endpoint
-            logging.info(f"Add endpoint domain: {domain_id}, key: {str(endpoint.key)}, entity: {entity_type}")
-            if domain_id in self.endpoints.keys():
-                self.endpoints[domain_id].append((entity_type, endpoint))
-            else:
-                self.endpoints[domain_id] = [(entity_type, endpoint)]
 
-            # check new topic
-            if domain_id in self.endpoints.keys():
-                already_endpoint_on_topic = False
-                for (_, endpoint_iter) in self.endpoints[domain_id]:
-                    if endpoint.topic_name == endpoint_iter.topic_name and endpoint.key != endpoint_iter.key:
-                        already_endpoint_on_topic = True
-                        break
-        
-                if not already_endpoint_on_topic:
-                    logging.info(f"New topic {str(endpoint.topic_name)}")
-                    self.new_topic_signal.emit(domain_id, endpoint.topic_name)
+        # logging.debug(f"Add endpoint domain: {domain_id}, key: {str(endpoint.key)}, entity: {entity_type}")
 
-                self.new_endpoint_signal.emit(domain_id, endpoint, entity_type)
+        if domain_id in self.the_domains:
+            topic_already_known = self.the_domains[domain_id].hash_topic(str(endpoint.topic_name))
+            dataEndp = DataEndpoint(endpoint, entity_type)
+            self.the_domains[domain_id].add_endpoint(dataEndp)
 
-            # check qos
-            self.check_qos_mismatches(domain_id)
+            if not topic_already_known:
+                self.new_topic_signal.emit(domain_id, endpoint.topic_name)
+
+            self.new_endpoint_signal.emit("", domain_id, copy.deepcopy(dataEndp))
+       
+            mismatches = self.the_domains[domain_id].topics[endpoint.topic_name].get_mismatches()
+            if len(mismatches) > 0:
+                self.publish_mismatch_signal.emit(domain_id, endpoint.topic_name, mismatches)
 
     @Slot(int, DcpsEndpoint)
     def remove_endpoint(self, domain_id: int, endpoint: DcpsEndpoint):
-        with self.mutex:
-            if domain_id in self.endpoints.keys():
-                available = -1
-                other_endpoint_on_topic = False
-                topic_name = ""
-                idx = -1
-                for (_, endpoint_iter) in self.endpoints[domain_id]:
-                    idx += 1
-                    if endpoint.key == endpoint_iter.key:
-                        available = idx
-                        topic_name = endpoint_iter.topic_name
-                        break
-                if available != -1:
-                    logging.info(f"Remove endpoint {str(endpoint.key)}")
-                    del self.endpoints[domain_id][idx]
-                    self.removed_endpoint_signal.emit(domain_id, str(endpoint.key))
 
-                # check if it was the last endpoint on its topic
-                for (_, endpoint_iter) in self.endpoints[domain_id]:
-                    if topic_name == endpoint_iter.topic_name:
-                        other_endpoint_on_topic = True
-                        break
-                if not other_endpoint_on_topic:
-                    logging.info(f"Remove topic {str(topic_name)}")
-                    self.remove_topic_signal.emit(domain_id, topic_name)
+        if domain_id in self.the_domains:
 
-            # check qos
-            self.no_more_mismatch_in_topic_signal.emit(domain_id, topic_name)
-            self.check_qos_mismatches(domain_id)     
+            topicName = self.the_domains[domain_id].get_topic_name(str(endpoint.key))
 
-    @Slot(int,result=[(EntityType, DcpsEndpoint)])
-    def getEndpoints(self, domain_id: int):
-        with self.mutex:
-            if domain_id in self.endpoints.keys():
-                return self.endpoints[domain_id]
+            self.the_domains[domain_id].remove_endpoint(str(endpoint.key))
 
-    @Slot(int, result=DcpsParticipant)
-    def getParticipants(self, domain_id: int):
-        with self.mutex:
-            if domain_id in self.participants.keys():
-                return self.participants[domain_id]
+            #logging.debug(f"Remove endpoint {str(endpoint.key)} (topic: {topicName})")
 
-    def getQosMismatches(self, domain_id: int, topic_name: str):
-        with self.mutex:
-            if domain_id in self.mismatches.keys() and domain_id in self.endpoints.keys():
-                topic_mismatches = {}
-                for (_, endpoint_iter) in self.endpoints[domain_id]:
-                    if topic_name == endpoint_iter.topic_name and str(endpoint_iter.key) in self.mismatches[domain_id].keys():
-                        topic_mismatches[str(endpoint_iter.key)] = self.mismatches[domain_id][str(endpoint_iter.key)]
-                return topic_mismatches
-        return {}
+            self.removed_endpoint_signal.emit(domain_id, str(endpoint.key))
+
+            if not self.the_domains[domain_id].hash_topic(topicName):
+                #logging.info(f"Removed last endpointon topic, topic gone {topicName}")
+                self.remove_topic_signal.emit(domain_id, topicName)
+            else:
+                self.no_more_mismatch_in_topic_signal.emit(domain_id, topicName)
+                mismatches = self.the_domains[domain_id].topics[topicName].get_mismatches()
+                if len(mismatches) > 0:
+                    self.publish_mismatch_signal.emit(domain_id, topicName, mismatches)
+
+    @Slot(str, int, str, EntityType)
+    def requestEndpointsSlot(self, requestId: str, domain_id: int, topic_name: str, entity_type: EntityType):
+        if domain_id in self.the_domains:
+            endDict = self.the_domains[domain_id].getEndpoints(topic_name, entity_type)
+            for key in endDict.keys():
+                self.new_endpoint_signal.emit(requestId, domain_id, copy.deepcopy(endDict[key]))

--- a/src/models/endpoint_model.py
+++ b/src/models/endpoint_model.py
@@ -127,19 +127,19 @@ class EndpointModel(QAbstractItemModel):
         elif role == self.ProcessNameRole:
             return Path(appname.replace("\\", f"{os.path.sep}")).stem
         elif role == self.EndpointHasQosMismatch:
-            if len(self.endpoints[endp_key].missmatches.keys()):
+            if len(self.endpoints[endp_key].mismatches.keys()):
                 return True
             return False
         elif role == self.EndpointQosMismatchText:
             qos_mm_txt = ""
-            if len(self.endpoints[endp_key].missmatches.keys()) > 0:
+            if len(self.endpoints[endp_key].mismatches.keys()) > 0:
                 qos_mm_txt += "\nQos-Mismatches:\n"
-                for idx, endp_mm in enumerate(self.endpoints[endp_key].missmatches.keys()):
-                    for idx_mm, mm_type in enumerate(self.endpoints[endp_key].missmatches[endp_mm]):
+                for idx, endp_mm in enumerate(self.endpoints[endp_key].mismatches.keys()):
+                    for idx_mm, mm_type in enumerate(self.endpoints[endp_key].mismatches[endp_mm]):
                         qos_mm_txt += "  " + str(mm_type) + " with " + str(endp_mm)
-                        if idx_mm < len(self.endpoints[endp_key].missmatches[endp_mm]) - 1:
+                        if idx_mm < len(self.endpoints[endp_key].mismatches[endp_mm]) - 1:
                             qos_mm_txt += "\n"
-                    if idx < len(self.endpoints[endp_key].missmatches.keys()) - 1:
+                    if idx < len(self.endpoints[endp_key].mismatches.keys()) - 1:
                         qos_mm_txt += "\n"
                 qos_mm_txt = qos_mm_txt.replace("dds_qos_policy_id.", "")
             return qos_mm_txt
@@ -189,10 +189,10 @@ class EndpointModel(QAbstractItemModel):
         if self.topic_name != endpointData.endpoint.topic_name:
             return
         if (endpointData.isReader() and EntityType.WRITER == self.entity_type) or (endpointData.isWriter() and EntityType.READER == self.entity_type):
-            if len(endpointData.missmatches.keys()) > 0:
-                for mismKey in endpointData.missmatches.keys():
+            if len(endpointData.mismatches.keys()) > 0:
+                for mismKey in endpointData.mismatches.keys():
                     if mismKey in self.endpoints:
-                        self.endpoints[mismKey].missmatches[str(endpointData.endpoint.key)] = endpointData.missmatches[mismKey]
+                        self.endpoints[mismKey].mismatches[str(endpointData.endpoint.key)] = endpointData.mismatches[mismKey]
                         idx = list(self.endpoints.keys()).index(mismKey)
                         index = self.createIndex(idx, 0)
                         self.dataChanged.emit(index, index, [self.EndpointHasQosMismatch, self.EndpointQosMismatchText])
@@ -211,7 +211,7 @@ class EndpointModel(QAbstractItemModel):
 
         self.totalEndpointsSignal.emit(len(self.endpoints))
 
-        if len(endpointData.missmatches.keys()) > 0:
+        if len(endpointData.mismatches.keys()) > 0:
             self.topicHasQosMismatchSignal.emit(True)
 
     @Slot(int, str)
@@ -227,8 +227,8 @@ class EndpointModel(QAbstractItemModel):
             self.totalEndpointsSignal.emit(len(self.endpoints))
         else:
             for endpKey in self.endpoints.keys():
-                if str(endpoint_key) in self.endpoints[endpKey].missmatches:
-                    del self.endpoints[endpKey].missmatches[str(endpoint_key)]
+                if str(endpoint_key) in self.endpoints[endpKey].mismatches:
+                    del self.endpoints[endpKey].mismatches[str(endpoint_key)]
                     idx = list(self.endpoints.keys()).index(endpKey)
                     index = self.createIndex(idx, 0)
                     self.dataChanged.emit(index, index, [self.EndpointHasQosMismatch, self.EndpointQosMismatchText])

--- a/src/utils.py
+++ b/src/utils.py
@@ -26,7 +26,13 @@ class EntityType(Enum):
     WRITER = 4
 
 def qt_message_handler(mode, context, message):
-    file = os.path.basename(context.file)
+    file = context.file
+    if file:
+        file = os.path.basename(file)
+    else:
+        file = "<unknown>"
+    if message.startswith("qrc:/"):
+        message = message[len("qrc:/"):] 
     log_msg = f"[{file}:{context.line}] {message}"
     if mode == QtCore.QtMsgType.QtInfoMsg:
         logging.info(log_msg)

--- a/src/views/ListenerView.qml
+++ b/src/views/ListenerView.qml
@@ -27,6 +27,9 @@ Rectangle {
     property bool autoScrollEnabled: true
     property string logCache: ""
 
+    border.color : autoScrollEnabled ? "transparent" : "orange"
+    border.width : 2
+
     function logClear() {
         listenerTextArea.text = ""
         logCache = ""
@@ -65,7 +68,7 @@ Rectangle {
                 onClicked: logClear()
             }
             Button {
-                text: listenerTabId.autoScrollEnabled ? "Stop Scroll" : "Start Scroll"
+                text: listenerTabId.autoScrollEnabled ? "Pause Messages" : "Resume Messages"
                 onClicked: {
                     listenerTabId.autoScrollEnabled = !listenerTabId.autoScrollEnabled
                     if (listenerTabId.autoScrollEnabled) {
@@ -98,6 +101,7 @@ Rectangle {
             color: rootWindow.isDarkMode ? "black" : "white"
             Layout.fillWidth: true
             Layout.fillHeight: true
+            Layout.margins: 3
 
             Flickable {
                 id: scrollView


### PR DESCRIPTION
When there was a single topic with more then 200+ endpoints the gui was not useable, it was freezing to death.
This PR fixes the performance issues, it now fully uses Signals/Slot (like qt suggest) and a performance fix in the qos check.
The data handling is now more Object-Oriented, resulting in less looping to avoid unneeded cpu time.

- fix freezing gui - tested it with 600+ endpoints on a topic.
- fix performance hungry QoS mismatch check, compare only smallest needed subset.
- fix app crash when user copied something to clipboard.
- fix layout, last endpoint was only half visible.
- fix missing scroll bar in endpoint overview.
- fix gui-model update, use add/remove instead reset model every time.

@eboasson may you can have a look? 😃 