### PR TITLE
fix nested struct idl import

### DIFF
--- a/src/views/ReaderTester.qml
+++ b/src/views/ReaderTester.qml
@@ -37,7 +37,7 @@ Popup {
     }
 
     function setType(topicType) {
-        topicNameTextFieldId.text = topicType.replace("::", "_")
+        topicNameTextFieldId.text = topicType.replace(/::/g, "_");
         readerTesterDiaId.topicType = topicType
     }
 


### PR DESCRIPTION
This PR fixes the import of structs nested in more than one module.
Previously only the top level structs were displayed.

With this PR now all structs are displayed, for example:
<img width="397" alt="Screenshot 2024-06-26 at 17 42 29" src="https://github.com/eclipse-cyclonedds/cyclonedds-insight/assets/45872415/3b7388ab-6eb5-4c39-8d6d-fa0a843e0a0a">
```
module vehicles 
{
    struct Vehicle 
    {
        string name;
        int64 x;
        int64 y;
    };

    module Engine
    {
        struct RealEngine
        {
            string name;
        };
    };

    module Wheel
    {
        struct GreatWheel
        {
            string name;
        };

            module CarPark
           {
        
                struct Car
                {
                    string name;
                };

        
                module vehicles2
                {
                    module vehicles3
                    {
                        struct Ultimate
                        {
                            string name;
                        };
                    };
               };
          };
     };
};
```

@eboasson would be cool when you can look into it :)