### PR TITLE
add fastdds participant information

### DIFF
--- a/src/models/endpoint_model.py
+++ b/src/models/endpoint_model.py
@@ -25,9 +25,9 @@ from dds_data import DataEndpoint
 from utils import EntityType
 
 
-HOSTNAMES     = ["__Hostname",    "dds.sys_info.hostname"]
+HOSTNAMES     = ["__Hostname",    "dds.sys_info.hostname", "fastdds.physical_data.host"]
 PROCESS_NAMES = ["__ProcessName", "dds.sys_info.executable_filepath"]
-PIDS          = ["__Pid",         "dds.sys_info.process_id"]
+PIDS          = ["__Pid",         "dds.sys_info.process_id", "fastdds.physical_data.process"]
 ADDRESSES     = ["__NetworkAddresses"]
 
 


### PR DESCRIPTION
Add participant information from fastdds vendor.
- hostname
- processId

The process name is not available in fastdds.
```
DcpsParticipant(
    key=UUID('010fe616-201f-c1bd-0000-0000000001c1'),
    qos=Qos(
        Policy.EntityName(name='Participant_pub'),
        Policy.Liveliness.Automatic(lease_duration=20000000000),
        Property(key="PARTICIPANT_TYPE", value="SIMPLE"),
        Property(key="__NetworkAddresses", value="udp/192.168.0.44:7410@7"),
        Property(key="fastdds.physical_data.host", value="trittsv-desktop:6303166390786064384"),
        Property(key="fastdds.physical_data.process", value="7968"),
        Property(key="fastdds.physical_data.user", value="sven")
    )
)
```

@eboasson would be cool if you could have a look :)