### PR TITLE
Implement all qos when creating a reader

### DIFF
--- a/src/dds_qos.py
+++ b/src/dds_qos.py
@@ -311,7 +311,7 @@ def partition_patmatch_p(pat, name):
 def partitions_match_default(x):
     if qos.Policy.Partition not in x or len(x[qos.Policy.Partition].partitions) == 0:
         return True
-    for i in range(len(x.partition)):
+    for i in range(len(x[qos.Policy.Partition].partitions)):
         if partition_patmatch_p(x[qos.Policy.Partition].partitions[i], ""):
             return True
     return False

--- a/src/dds_service.py
+++ b/src/dds_service.py
@@ -114,7 +114,7 @@ class WorkerThread(QThread):
         try:
             topic = Topic(self.domain_participant, topic_name, topic_type, qos=qos)
             subscriber = Subscriber(self.domain_participant, qos=qos)
-            reader = DataReader(subscriber, topic)
+            reader = DataReader(subscriber, topic, qos=qos)
             readCondition = core.ReadCondition(reader, SampleState.Any | ViewState.Any | InstanceState.Any)
             self.waitset.attach(readCondition)
 

--- a/src/dds_service.py
+++ b/src/dds_service.py
@@ -113,7 +113,7 @@ class WorkerThread(QThread):
         logging.info("Add reader")
         try:
             topic = Topic(self.domain_participant, topic_name, topic_type, qos=qos)
-            subscriber = Subscriber(self.domain_participant)
+            subscriber = Subscriber(self.domain_participant, qos=qos)
             reader = DataReader(subscriber, topic)
             readCondition = core.ReadCondition(reader, SampleState.Any | ViewState.Any | InstanceState.Any)
             self.waitset.attach(readCondition)

--- a/src/models/datamodel_model.py
+++ b/src/models/datamodel_model.py
@@ -207,7 +207,7 @@ class DatamodelModel(QAbstractListModel):
         writer_life_autodispose,
         reader_life_nowriter_delay, reader_life_disposed, transport_prio,
         limit_max_samples, limit_max_instances, limit_max_samples_per_instance,
-        timebased_filter_time, ignore_local,
+        timebased_filter_time_sec, ignore_local,
         user_data, group_data, entity_name, prop_name, prop_value, bin_prop_name, bin_prop_value):
 
         logging.debug("try add reader" + str(domain_id) + str(topic_name) + str(topic_type) + str(q_own) + str(q_dur) + str(q_rel))
@@ -296,7 +296,7 @@ class DatamodelModel(QAbstractListModel):
             qos += Qos(Policy.TransportPriority(transport_prio))
             qos += Qos(Policy.ResourceLimits(
                 max_samples=limit_max_samples, max_instances=limit_max_instances, max_samples_per_instance=limit_max_samples_per_instance))
-            qos += Qos(Policy.TimeBasedFilter(filter_time=timebased_filter_time))
+            qos += Qos(Policy.TimeBasedFilter(filter_time=duration(seconds=timebased_filter_time_sec)))
 
             if ignore_local == "Nothing":
                 qos += Qos(Policy.IgnoreLocal.Nothing)

--- a/src/models/datamodel_model.py
+++ b/src/models/datamodel_model.py
@@ -195,8 +195,8 @@ class DatamodelModel(QAbstractListModel):
                     self.dataModelItems[sId] = DataModelItem(sId, [module.__name__, cls.__name__])
                     self.endInsertRows()
 
-    @Slot(int, str, str, str, str, str)
-    def addReader(self, domain_id, topic_name, topic_type, q_own, q_dur, q_rel):
+    @Slot(int, str, str, str, str, str, bool, bool, list)
+    def addReader(self, domain_id, topic_name, topic_type, q_own, q_dur, q_rel, q_xcdr1, q_xcdr2, parititons):
         logging.debug("try add reader" + str(domain_id) + str(topic_name) + str(topic_type) + str(q_own) + str(q_dur) + str(q_rel))
 
         if topic_type in self.dataModelItems:
@@ -226,6 +226,12 @@ class DatamodelModel(QAbstractListModel):
                 qos += Qos(Policy.Reliability.BestEffort)
             elif q_rel == "DDS_RELIABILITY_RELIABLE":
                 qos += Qos(Policy.Reliability.Reliable(max_blocking_time=duration(seconds=1)))
+
+            if q_xcdr1 or q_xcdr2:
+                qos += Qos(Policy.DataRepresentation(use_cdrv0_representation=q_xcdr1, use_xcdrv2_representation=q_xcdr2))
+
+            if len(parititons) > 0:
+                qos += Qos(Policy.Partition(partitions=parititons))
 
             if domain_id in self.threads:
                 self.threads[domain_id].receive_data(topic_name, class_type, qos)

--- a/src/models/datamodel_model.py
+++ b/src/models/datamodel_model.py
@@ -195,8 +195,21 @@ class DatamodelModel(QAbstractListModel):
                     self.dataModelItems[sId] = DataModelItem(sId, [module.__name__, cls.__name__])
                     self.endInsertRows()
 
-    @Slot(int, str, str, str, str, str, bool, bool, list)
-    def addReader(self, domain_id, topic_name, topic_type, q_own, q_dur, q_rel, q_xcdr1, q_xcdr2, parititons):
+    @Slot(int, str, str, str, str, str, int, bool, bool, list, str, bool, bool, bool, bool, bool, bool, str, int, str, str, int, int, int, int, int, str, bool, bool, bool, int, int, int, int, int, int, int, str, str, str, str, str, str, str, str)
+    def addReader(self, domain_id, topic_name, topic_type,
+        q_own, q_dur, q_rel, q_rel_max_block_msec, q_xcdr1, q_xcdr2, parititons,
+        type_consis, ig_seq_bnds, ig_str_bnds, ign_mem_nam, prev_ty_wide, fore_type_vali, fore_type_vali_allow,
+        history, history_keep_last_nr,
+        destination_order,
+        liveliness, liveliness_seconds,
+        lifespan_seconds, deadline_seconds, latencybudget_seconds, owner_strength,
+        presentation_access_scope, pres_acc_scope_coherent, pres_acc_scope_ordered,
+        writer_life_autodispose,
+        reader_life_nowriter_delay, reader_life_disposed, transport_prio,
+        limit_max_samples, limit_max_instances, limit_max_samples_per_instance,
+        timebased_filter_time, ignore_local,
+        user_data, group_data, entity_name, prop_name, prop_value, bin_prop_name, bin_prop_value):
+
         logging.debug("try add reader" + str(domain_id) + str(topic_name) + str(topic_type) + str(q_own) + str(q_dur) + str(q_rel))
 
         if topic_type in self.dataModelItems:
@@ -225,13 +238,88 @@ class DatamodelModel(QAbstractListModel):
             if q_rel == "DDS_RELIABILITY_BEST_EFFORT":
                 qos += Qos(Policy.Reliability.BestEffort)
             elif q_rel == "DDS_RELIABILITY_RELIABLE":
-                qos += Qos(Policy.Reliability.Reliable(max_blocking_time=duration(seconds=1)))
+                qos += Qos(Policy.Reliability.Reliable(max_blocking_time=duration(milliseconds=q_rel_max_block_msec)))
+
+            if len(parititons) > 0:
+                qos += Qos(Policy.Partition(partitions=parititons))
 
             if q_xcdr1 or q_xcdr2:
                 qos += Qos(Policy.DataRepresentation(use_cdrv0_representation=q_xcdr1, use_xcdrv2_representation=q_xcdr2))
 
-            if len(parititons) > 0:
-                qos += Qos(Policy.Partition(partitions=parititons))
+            if type_consis == "AllowTypeCoercion":
+                qos += Qos(Policy.TypeConsistency.AllowTypeCoercion(
+                    ignore_sequence_bounds=ig_seq_bnds,
+                    ignore_string_bounds=ig_str_bnds,
+                    ignore_member_names=ign_mem_nam,
+                    prevent_type_widening=prev_ty_wide,
+                    force_type_validation=fore_type_vali))
+            elif type_consis == "DisallowTypeCoercion":
+                qos += Qos(Policy.TypeConsistency.DisallowTypeCoercion(force_type_validation=fore_type_vali_allow))
+
+            if history == "KeepAll":
+                qos += Qos(Policy.History.KeepAll)
+            elif history == "KeepLast":
+                qos += Qos(Policy.History.KeepLast(history_keep_last_nr))
+
+            if destination_order == "ByReceptionTimestamp":
+                qos += Qos(Policy.DestinationOrder.ByReceptionTimestamp)
+            elif destination_order == "BySourceTimestamp":
+                qos += Qos(Policy.DestinationOrder.BySourceTimestamp)
+
+            liveliness_duration = duration(seconds=liveliness_seconds) if liveliness_seconds >= 0 else duration(infinite=True)
+            if liveliness == "Automatic":
+                qos += Qos(Policy.Liveliness.Automatic(liveliness_duration))
+            elif liveliness == "ManualByParticipant":
+                qos += Qos(Policy.Liveliness.ManualByParticipant(liveliness_duration))
+            elif liveliness == "ManualByTopic":
+                qos += Qos(Policy.Liveliness.ManualByTopic(liveliness_duration))
+
+            qos += Qos(Policy.Lifespan(duration(seconds=lifespan_seconds) if lifespan_seconds >= 0 else duration(infinite=True)))
+            qos += Qos(Policy.Deadline(duration(seconds=deadline_seconds) if deadline_seconds >= 0 else duration(infinite=True)))
+            qos += Qos(Policy.LatencyBudget(duration(seconds=latencybudget_seconds) if latencybudget_seconds >= 0 else duration(infinite=True)))
+            qos += Qos(Policy.OwnershipStrength(owner_strength))
+
+            if presentation_access_scope == "Instance":
+                qos += Qos(Policy.PresentationAccessScope.Instance(coherent_access=pres_acc_scope_coherent, ordered_access=pres_acc_scope_ordered))
+            elif presentation_access_scope == "Topic":
+                qos += Qos(Policy.PresentationAccessScope.Topic(coherent_access=pres_acc_scope_coherent, ordered_access=pres_acc_scope_ordered))
+            elif presentation_access_scope == "Group":
+                qos += Qos(Policy.PresentationAccessScope.Group(coherent_access=pres_acc_scope_coherent, ordered_access=pres_acc_scope_ordered))
+
+            qos += Qos(Policy.WriterDataLifecycle(autodispose=writer_life_autodispose))
+
+            qos += Qos(Policy.ReaderDataLifecycle(
+                autopurge_nowriter_samples_delay=duration(seconds=reader_life_nowriter_delay) if reader_life_nowriter_delay >= 0 else duration(infinite=True),
+                autopurge_disposed_samples_delay=duration(seconds=reader_life_disposed) if reader_life_disposed >= 0 else duration(infinite=True)
+            ))
+
+            qos += Qos(Policy.TransportPriority(transport_prio))
+            qos += Qos(Policy.ResourceLimits(
+                max_samples=limit_max_samples, max_instances=limit_max_instances, max_samples_per_instance=limit_max_samples_per_instance))
+            qos += Qos(Policy.TimeBasedFilter(filter_time=timebased_filter_time))
+
+            if ignore_local == "Nothing":
+                qos += Qos(Policy.IgnoreLocal.Nothing)
+            elif ignore_local == "Participant":
+                qos += Qos(Policy.IgnoreLocal.Participant)
+            elif ignore_local == "Process":
+                qos += Qos(Policy.IgnoreLocal.Process)
+
+            if user_data:
+                qos += Qos(Policy.Userdata(data=user_data.encode('utf-8')))
+
+            if group_data:
+                qos += Qos(Policy.Groupdata(data=group_data.encode('utf-8')))
+
+            if entity_name:
+                qos += Qos(Policy.EntityName(name=entity_name))
+
+            if prop_name and prop_value:
+                qos += Qos(Policy.Property(key=prop_name, value=prop_value))
+
+            if bin_prop_name and bin_prop_value:
+                qos += Qos(Policy.BinaryProperty(key=bin_prop_name, value=bin_prop_value.encode('utf-8')))
+
 
             if domain_id in self.threads:
                 self.threads[domain_id].receive_data(topic_name, class_type, qos)

--- a/src/views/ReaderTester.qml
+++ b/src/views/ReaderTester.qml
@@ -97,13 +97,26 @@ Popup {
             }
 
             Label {
-                text: "Ownership"
+                text: "Reliability"
                 font.bold: true
             }
-            ComboBox {
-                id: ownershipComboId
-                model: ["DDS_OWNERSHIP_SHARED", "DDS_OWNERSHIP_EXCLUSIVE"]
-                width: readerTesterDiaId.width - 30
+            Column {
+                ComboBox {
+                    id: reliabilityComboId
+                    model: ["DDS_RELIABILITY_BEST_EFFORT", "DDS_RELIABILITY_RELIABLE"]
+                    width: readerTesterDiaId.width - 30
+                }
+                Row {
+                    visible: reliabilityComboId.currentText === "DDS_RELIABILITY_RELIABLE" 
+                    Label {
+                        text: "max_blocking_time in milliseconds: "
+                    }
+                    SpinBox {
+                        id: reliabilitySpinBox
+                        to: 1e9
+                        value: 100
+                    }
+                }
             }
 
             Label {
@@ -117,12 +130,12 @@ Popup {
             }
 
             Label {
-                text: "Reliability"
+                text: "Ownership"
                 font.bold: true
             }
             ComboBox {
-                id: reliabilityComboId
-                model: ["DDS_RELIABILITY_BEST_EFFORT", "DDS_RELIABILITY_RELIABLE"]
+                id: ownershipComboId
+                model: ["DDS_OWNERSHIP_SHARED", "DDS_OWNERSHIP_EXCLUSIVE"]
                 width: readerTesterDiaId.width - 30
             }
 
@@ -209,6 +222,405 @@ Popup {
                     }
                 }
             }
+
+            Label {
+                text: "TypeConsistency"
+                font.bold: true
+            }
+            Column {
+                ComboBox {
+                    id: typeConsistencyComboId
+                    model: ["AllowTypeCoercion", "DisallowTypeCoercion"]
+                    width: readerTesterDiaId.width - 30
+                }
+                Column {
+                    visible: typeConsistencyComboId.currentText === "AllowTypeCoercion"
+                    Row {
+                        CheckBox {
+                            id: allowTypeCoercion_ignore_sequence_bounds
+                            checked: true
+                            text: qsTr("ignore_sequence_bounds")
+                        }
+                        CheckBox {
+                            id: allowTypeCoercion_ignore_string_bounds
+                            checked: true
+                            text: qsTr("ignore_string_bounds")
+                        }
+                        CheckBox {
+                            id: allowTypeCoercion_ignore_member_names
+                            checked: true
+                            text: qsTr("ignore_member_names")
+                        }
+                    }
+                    Row {
+                        CheckBox {
+                            id: allowTypeCoercion_prevent_type_widening
+                            checked: false
+                            text: qsTr("prevent_type_widening")
+                        }
+                        CheckBox {
+                            id: allowTypeCoercion_force_type_validation
+                            checked: false
+                            text: qsTr("force_type_validation")
+                        }
+                    }
+                }
+
+                CheckBox {
+                    id: disallowTypeCoercionForce_type_validationCheckbox
+                    checked: false
+                    text: qsTr("force_type_validation")
+                    visible: typeConsistencyComboId.currentText === "DisallowTypeCoercion" 
+                }
+            }
+
+            Label {
+                text: "History"
+                font.bold: true
+            }
+            Row {
+                ComboBox {
+                    id: historyComboId
+                    model: ["KeepLast", "KeepAll"]
+                    width: readerTesterDiaId.width - 30
+                }
+                SpinBox {
+                    id: keepLastSpinBox
+                    to: 1e9
+                    value: 1
+                    enabled: historyComboId.currentText === "KeepLast"
+                }
+            }
+
+            Label {
+                text: "DestinationOrder"
+                font.bold: true
+            }
+            ComboBox {
+                id: destinationOrderComboId
+                model: ["ByReceptionTimestamp", "BySourceTimestamp"]
+                width: readerTesterDiaId.width - 30
+            }
+
+            Label {
+                text: "Liveliness"
+                font.bold: true
+            }
+            Column {
+                ComboBox {
+                    id: livelinessComboId
+                    model: ["Automatic", "ManualByParticipant", "ManualByTopic"]
+                    width: readerTesterDiaId.width - 30
+                }
+                Row {
+                    Label {
+                        text: "Seconds: "
+                    }
+                    SpinBox {
+                        id: livelinessSpinBox
+                        to: 1e9
+                        value: 1
+                        enabled: !livelinessCheckbox.checked
+                    }
+                    CheckBox {
+                        id: livelinessCheckbox
+                        checked: true
+                        text: qsTr("infinite")
+                    }
+                }
+            }
+
+            Label {
+                text: "Lifespan"
+                font.bold: true
+            }
+            Row {
+                Label {
+                    text: "Seconds: "
+                }
+                SpinBox {
+                    id: lifespanSpinBox
+                    to: 1e9
+                    value: 2
+                    enabled: !lifespanCheckbox.checked
+                }
+                CheckBox {
+                    id: lifespanCheckbox
+                    checked: true
+                    text: qsTr("infinite")
+                }
+            }
+
+            Label {
+                text: "Deadline"
+                font.bold: true
+            }
+            Row {
+                Label {
+                    text: "Seconds: "
+                }
+                SpinBox {
+                    id: deadlineSpinBox
+                    to: 1e9
+                    value: 2
+                    enabled: !deadlineCheckbox.checked
+                }
+                CheckBox {
+                    id: deadlineCheckbox
+                    checked: true
+                    text: qsTr("infinite")
+                }
+            }
+
+            Label {
+                text: "LatencyBudget"
+                font.bold: true
+            }
+            Row {
+                Label {
+                    text: "Seconds: "
+                }
+                SpinBox {
+                    id: latencyBudgetSpinBox
+                    to: 1e9
+                    value: 2
+                    enabled: !latencyBudgetCheckbox.checked
+                }
+                CheckBox {
+                    id: latencyBudgetCheckbox
+                    checked: true
+                    text: qsTr("infinite")
+                }
+            }
+
+            Label {
+                text: "OwnershipStrength"
+                font.bold: true
+            }
+            SpinBox {
+                id: ownershipStrengthSpinBox
+                to: 1e9
+                value: 0
+            }
+
+            Label {
+                text: "PresentationAccessScope"
+                font.bold: true
+            }
+            Column {
+                ComboBox {
+                    id: presentationAccessScopeComboId
+                    model: ["Instance", "Topic", "Group"]
+                    width: readerTesterDiaId.width - 30
+                }
+                Row {
+                    CheckBox {
+                        id: coherent_accessCheckbox
+                        checked: false
+                        text: qsTr("coherent_access")
+                    }
+                    CheckBox {
+                        id: ordered_accessCheckbox
+                        checked: false
+                        text: qsTr("ordered_access")
+                    }
+                }
+            }
+            Label {
+                text: "WriterDataLifecycle"
+                font.bold: true
+            }
+            CheckBox {
+                id: writerDataLifecycleCheckbox
+                checked: true
+                text: qsTr("autodispose")
+            }
+
+            Label {
+                text: "ReaderDataLifecycle"
+                font.bold: true
+            }
+            Column {
+                Row {
+                    Label {
+                        text: "autopurge_nowriter_samples_delay in minutes: "
+                    }
+                    SpinBox {
+                        id: autopurge_nowriter_samples_delaySpinBox
+                        to: 1e9
+                        value: 1
+                        enabled: !autopurge_nowriter_samples_delayCheckbox.checked
+                    }
+                    CheckBox {
+                        id: autopurge_nowriter_samples_delayCheckbox
+                        checked: true
+                        text: qsTr("infinite")
+                    }
+                }
+                Row {
+                    Label {
+                        text: "autopurge_disposed_samples_delay in minutes: "
+                    }
+                    SpinBox {
+                        id: autopurge_disposed_samples_delaySpinBox
+                        to: 1e9
+                        value: 1
+                        enabled: !autopurge_disposed_samples_delaySpinBoxCheckbox.checked
+                    }
+                    CheckBox {
+                        id: autopurge_disposed_samples_delaySpinBoxCheckbox
+                        checked: true
+                        text: qsTr("infinite")
+                    }
+                }
+
+            }
+
+            Label {
+                text: "TransportPriority"
+                font.bold: true
+            }
+            SpinBox {
+                id: transportPrioritySpinBox
+                to: 1e9
+                value: 0
+            }
+            
+            Label {
+                text: "ResourceLimits"
+                font.bold: true
+            }
+            Column {
+                Row {
+                    Label {
+                        text: "max_samples"
+                    }
+                    SpinBox {
+                        id: max_samplesSpinBox
+                        from: -1
+                        to: 1e9
+                        value: -1
+                    }
+                }
+                Row {
+                    Label {
+                        text: "max_instances"
+                    }
+                    SpinBox {
+                        id: max_instancesSpinBox
+                        from: -1
+                        to: 1e9
+                        value: -1
+                    }
+                }
+                Row {
+                    Label {
+                        text: "max_samples_per_instance"
+                    }
+                    SpinBox {
+                        id: max_samples_per_instanceSpinBox
+                        from: -1
+                        to: 1e9
+                        value: -1
+                    }
+                }
+            }
+
+            Label {
+                text: "TimeBasedFilter"
+                font.bold: true
+            }
+            Row {
+                Label {
+                    text: "filter_fn in seconds: "
+                }
+                SpinBox {
+                    id: timeBasedFilterSpinBox
+                    to: 1e9
+                    value: 0
+                }
+            }
+
+            Label {
+                text: "IgnoreLocal"
+                font.bold: true
+            }
+            ComboBox {
+                id: ignoreLocalComboId
+                model: ["Nothing", "Participant", "Process"]
+                width: readerTesterDiaId.width - 30
+            }
+
+            Label {
+                text: "Userdata"
+                font.bold: true
+            }
+            TextField {
+                leftPadding: 10
+                id: userdataField
+                placeholderText: "Enter Userdata"
+                text: ""
+            }
+
+            Label {
+                text: "Groupdata"
+                font.bold: true
+            }
+            TextField {
+                leftPadding: 10
+                id: groupdataField
+                placeholderText: "Enter Groupdata"
+                text: ""
+            }
+
+            Label {
+                text: "EntityName"
+                font.bold: true
+            }
+            TextField {
+                leftPadding: 10
+                id: entityNameField
+                placeholderText: "Enter EntityName"
+                text: ""
+            }
+
+            Label {
+                text: "Property"
+                font.bold: true
+            }
+            Row {
+                TextField {
+                    leftPadding: 10
+                    id: propertyKeyField
+                    placeholderText: "Enter key"
+                    text: ""
+                }
+                TextField {
+                    leftPadding: 10
+                    id: propertyValueField
+                    placeholderText: "Enter value"
+                    text: ""
+                }
+            }
+
+            Label {
+                text: "BinaryProperty"
+                font.bold: true
+            }
+            Row {
+                TextField {
+                    leftPadding: 10
+                    id: binaryPropertyKeyField
+                    placeholderText: "Enter key"
+                    text: ""
+                }
+                TextField {
+                    leftPadding: 10
+                    id: binaryPropertyValueField
+                    placeholderText: "Enter value"
+                    text: ""
+                }
+            }
         }
     }
 
@@ -234,9 +646,45 @@ Popup {
                     ownershipComboId.currentText,
                     durabilityComboId.currentText,
                     reliabilityComboId.currentText,
+                    reliabilitySpinBox.value,
                     dataReprXcdr1Checkbox.checked,
                     dataReprXcdr2Checkbox.checked,
-                    partitions
+                    partitions,
+                    typeConsistencyComboId.currentText,
+                    allowTypeCoercion_ignore_sequence_bounds.checked,
+                    allowTypeCoercion_ignore_string_bounds.checked,
+                    allowTypeCoercion_ignore_member_names.checked,
+                    allowTypeCoercion_prevent_type_widening.checked,
+                    allowTypeCoercion_force_type_validation.checked,
+                    disallowTypeCoercionForce_type_validationCheckbox.checked,
+                    historyComboId.currentText,
+                    keepLastSpinBox.value,
+                    destinationOrderComboId.currentText,
+                    livelinessComboId.currentText,
+                    livelinessCheckbox.checked ? -1 : livelinessSpinBox.value,
+                    lifespanCheckbox.checked ? -1 : lifespanSpinBox.value,
+                    deadlineCheckbox.checked ? -1 : deadlineSpinBox.value,
+                    latencyBudgetCheckbox.checked ? -1 : latencyBudgetSpinBox.value,
+                    ownershipStrengthSpinBox.value,
+                    presentationAccessScopeComboId.currentText,
+                    coherent_accessCheckbox.checked,
+                    ordered_accessCheckbox.checked,
+                    writerDataLifecycleCheckbox.checked,
+                    autopurge_nowriter_samples_delayCheckbox.checked ? -1 : autopurge_nowriter_samples_delaySpinBox.value,
+                    autopurge_disposed_samples_delaySpinBoxCheckbox.checked ? -1 : autopurge_disposed_samples_delaySpinBox.value,
+                    transportPrioritySpinBox.value,
+                    max_samplesSpinBox.value,
+                    max_instancesSpinBox.value,
+                    max_samples_per_instanceSpinBox.value,
+                    timeBasedFilterSpinBox.value,
+                    ignoreLocalComboId.currentText,
+                    userdataField.text,
+                    groupdataField.text,
+                    entityNameField.text,
+                    propertyKeyField.text,
+                    propertyValueField.text,
+                    binaryPropertyKeyField.text,
+                    binaryPropertyValueField.text
                 )
                 readerTesterDiaId.close()
             }

--- a/src/views/ReaderTester.qml
+++ b/src/views/ReaderTester.qml
@@ -41,99 +41,211 @@ Popup {
         readerTesterDiaId.topicType = topicType
     }
 
-    Column {
-        anchors.fill: parent
-        spacing: 5
-        padding: 0
+    ListModel {
+        id: partitionModel
+    }
 
-        Label {
-            text: "Create Reader"
-            font.bold: true
-            font.pixelSize: 30
-            Layout.alignment: Qt.AlignHCenter
-        }
+    ScrollView {
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: buttonRow.top
+        clip: true
 
-        Label {
-            text: "Domain"
-            font.bold: true
-        }
-        SpinBox {
-            id: readerDomainIdSpinBox
-            value: 0
-            editable: false
-            from: 0
-            to: 232
-        }
+        ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+        ScrollBar.vertical.policy: ScrollBar.AsNeeded
 
-        Label {
-            text: "Topic Type"
-            font.bold: true
-        }
-        Label {
-            text: readerTesterDiaId.topicType
-        }
+        Column {
+            anchors.fill: parent
+            spacing: 5
+            padding: 5
 
-        Label {
-            text: "Topic Name"
-            font.bold: true
-        }
-        TextField {
-            id: topicNameTextFieldId
-            width: readerTesterDiaId.width - 20
-        }
+            Label {
+                text: "Create Reader"
+                font.bold: true
+                font.pixelSize: 30
+                Layout.alignment: Qt.AlignHCenter
+            }
 
-        Label {
-            text: "Ownership"
-            font.bold: true
-        }
-        ComboBox {
-            id: ownershipComboId
-            model: ["DDS_OWNERSHIP_SHARED", "DDS_OWNERSHIP_EXCLUSIVE"]
-            width: readerTesterDiaId.width - 20
-        }
+            Label {
+                text: "Domain"
+                font.bold: true
+            }
+            SpinBox {
+                id: readerDomainIdSpinBox
+                value: 0
+                editable: false
+                from: 0
+                to: 232
+            }
 
-        Label {
-            text: "Durability"
-            font.bold: true
-        }
-        ComboBox {
-            id: durabilityComboId
-            model: ["DDS_DURABILITY_VOLATILE", "DDS_DURABILITY_TRANSIENT_LOCAL", "DDS_DURABILITY_TRANSIENT", "DDS_DURABILITY_PERSISTENT"]
-            width: readerTesterDiaId.width - 20
-        }
+            Label {
+                text: "Topic Type"
+                font.bold: true
+            }
+            Label {
+                text: readerTesterDiaId.topicType
+            }
 
-        Label {
-            text: "Reliability"
-            font.bold: true
-        }
-        ComboBox {
-            id: reliabilityComboId
-            model: ["DDS_RELIABILITY_BEST_EFFORT", "DDS_RELIABILITY_RELIABLE"]
-            width: readerTesterDiaId.width - 20
-        }
+            Label {
+                text: "Topic Name"
+                font.bold: true
+            }
+            TextField {
+                id: topicNameTextFieldId
+                width: readerTesterDiaId.width - 40
+            }
 
-        Row {
-            Button {
-                text: qsTr("Create Reader")
-                onClicked: {
-                    datamodelRepoModel.addReader(
-                        readerDomainIdSpinBox.value,
-                        topicNameTextFieldId.text,
-                        topicType,
-                        ownershipComboId.currentText,
-                        durabilityComboId.currentText,
-                        reliabilityComboId.currentText
-                    )
-                    readerTesterDiaId.close()
+            Label {
+                text: "Ownership"
+                font.bold: true
+            }
+            ComboBox {
+                id: ownershipComboId
+                model: ["DDS_OWNERSHIP_SHARED", "DDS_OWNERSHIP_EXCLUSIVE"]
+                width: readerTesterDiaId.width - 30
+            }
+
+            Label {
+                text: "Durability"
+                font.bold: true
+            }
+            ComboBox {
+                id: durabilityComboId
+                model: ["DDS_DURABILITY_VOLATILE", "DDS_DURABILITY_TRANSIENT_LOCAL", "DDS_DURABILITY_TRANSIENT", "DDS_DURABILITY_PERSISTENT"]
+                width: readerTesterDiaId.width - 30
+            }
+
+            Label {
+                text: "Reliability"
+                font.bold: true
+            }
+            ComboBox {
+                id: reliabilityComboId
+                model: ["DDS_RELIABILITY_BEST_EFFORT", "DDS_RELIABILITY_RELIABLE"]
+                width: readerTesterDiaId.width - 30
+            }
+
+            Column {
+                Label {
+                    text: "Partitions"
+                    font.bold: true
+                }
+
+                Button {
+                    text: "Add Partition"
+                    onClicked: partitionModel.append({"partition": ""})
                 }
             }
-            Button {
-                text: qsTr("Cancel")
-                onClicked: {
-                    readerTesterDiaId.close()
+            Repeater {
+                model: partitionModel
+
+                Row {
+                    spacing: 10
+                    Rectangle {
+                        width: 20
+                        height: partitionField.height
+                        color: "transparent"
+                    }
+                    TextField {
+                        leftPadding: 10
+                        id: partitionField
+                        placeholderText: "Enter partition"
+                        text: modelData
+                        onTextChanged: partitionModel.set(index, {"partition": text})
+                    }
+                    Button {
+                        text: "Remove"
+                        onClicked: partitionModel.remove(index)
+                    }
+                }
+            }
+
+            Label {
+                text: "DataRepresentation"
+                font.bold: true
+            }
+            Row {
+                CheckBox {
+                    id: dataReprDefaultCheckbox
+                    checked: true
+                    text: qsTr("Default")
+                    onCheckedChanged: {
+                        if (checked) {
+                            dataReprXcdr1Checkbox.checked = false;
+                            dataReprXcdr2Checkbox.checked = false;
+                        }
+                        if (!dataReprXcdr1Checkbox.checked && !dataReprXcdr2Checkbox.checked) {
+                            checked = true;
+                        }
+                    }
+                }
+                CheckBox {
+                    id: dataReprXcdr1Checkbox
+                    checked: false
+                    text: qsTr("XCDR1")
+                    onCheckedChanged: {
+                        if (checked) {
+                            dataReprDefaultCheckbox.checked = false;
+                        } else {
+                            if (!dataReprXcdr2Checkbox.checked) {
+                                dataReprDefaultCheckbox.checked = true;
+                            }
+                        }
+                    }
+                }
+                CheckBox {
+                    id: dataReprXcdr2Checkbox
+                    checked: false
+                    text: qsTr("XCDR2")
+                    onCheckedChanged: {
+                        if (checked) {
+                            dataReprDefaultCheckbox.checked = false;
+                        } else {
+                            if (!dataReprXcdr1Checkbox.checked) {
+                                dataReprDefaultCheckbox.checked = true;
+                            }
+                        }
+                    }
                 }
             }
         }
     }
 
+    Row {
+        id: buttonRow
+        spacing: 10
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: 10
+
+        Button {
+            text: qsTr("Create Reader")
+            onClicked: {
+                var partitions = [];
+                for (var i = 0; i < partitionModel.count; i++) {
+                    partitions.push(partitionModel.get(i).partition);
+                }
+                datamodelRepoModel.addReader(
+                    readerDomainIdSpinBox.value,
+                    topicNameTextFieldId.text,
+                    topicType,
+                    ownershipComboId.currentText,
+                    durabilityComboId.currentText,
+                    reliabilityComboId.currentText,
+                    dataReprXcdr1Checkbox.checked,
+                    dataReprXcdr2Checkbox.checked,
+                    partitions
+                )
+                readerTesterDiaId.close()
+            }
+        }
+        Button {
+            text: qsTr("Cancel")
+            onClicked: {
+                readerTesterDiaId.close()
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR adds the possibility to set all available QoS when creating a reader from the Data Model.
Also fixes a bug in partitions qos match check.

Image 1/2: Empty Partition and Default DataRepresentation
<img width="1098" alt="Screenshot 2024-09-23 at 22 33 52" src="https://github.com/user-attachments/assets/9fc9cf67-71f3-4518-9049-f8560b413a41">

Image 2/2: Two partitions and XCDR2 DataRepresentation
<img width="1094" alt="Screenshot 2024-09-23 at 22 37 17" src="https://github.com/user-attachments/assets/d04fa815-e5e3-40d5-a984-6b79821791e2">

@eboasson could you have a look? 😃 