### PR TITLE
about window

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -35,5 +35,6 @@
         <file>src/views/ReaderTester.qml</file>
         <file>src/views/ListenerView.qml</file>
         <file>src/views/LoadingView.qml</file>
+        <file>src/views/AboutWindow.qml</file>
     </qresource>
 </RCC>

--- a/src/main.py
+++ b/src/main.py
@@ -84,6 +84,7 @@ if __name__ == "__main__":
     engine.rootContext().setContextProperty("treeModel", treeModel)
     engine.rootContext().setContextProperty("datamodelRepoModel", datamodelRepoModel)
     engine.rootContext().setContextProperty("CYCLONEDDS_URI", os.getenv("CYCLONEDDS_URI", "<not set>"))
+    engine.rootContext().setContextProperty("CYCLONEDDS_INSIGHT_VERSION", "0.0.0")
     qmlRegisterType(EndpointModel, "org.eclipse.cyclonedds.insight", 1, 0, "EndpointModel")
 
     engine.load(QUrl("qrc:/src/views/main.qml"))

--- a/src/views/AboutWindow.qml
+++ b/src/views/AboutWindow.qml
@@ -1,3 +1,15 @@
+/*
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+*/
+
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts

--- a/src/views/AboutWindow.qml
+++ b/src/views/AboutWindow.qml
@@ -19,12 +19,17 @@ import org.eclipse.cyclonedds.insight
 
 Window {
     id: aboutWindow
-    width: 500
-    height: 200
-    minimumWidth: 500
-    minimumHeight: 200
-    maximumWidth: 500
-    maximumHeight: 200
+
+    property int aboutWidth: 500
+    property int aboutHeight: 200
+
+    width: aboutWidth
+    height: aboutHeight
+    minimumWidth: aboutWidth
+    minimumHeight: aboutHeight
+    maximumWidth: aboutWidth
+    maximumHeight: aboutHeight
+
     title: "About CycloneDDS Insight"
     visible: false
     flags: Qt.Dialog

--- a/src/views/AboutWindow.qml
+++ b/src/views/AboutWindow.qml
@@ -1,0 +1,71 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import org.eclipse.cyclonedds.insight
+
+
+Window {
+    id: aboutWindow
+    width: 500
+    height: 200
+    minimumWidth: 500
+    minimumHeight: 200
+    maximumWidth: 500
+    maximumHeight: 200
+    title: "About CycloneDDS Insight"
+    visible: false
+    flags: Qt.Dialog
+    modality: Qt.ApplicationModal
+
+    color: rootWindow.isDarkMode ? Constants.darkOverviewBackground : Constants.lightOverviewBackground
+
+    RowLayout {
+        anchors.fill: parent
+
+        Rectangle {
+            Layout.preferredWidth: parent.width * 0.33
+            Layout.fillHeight: true
+            color: rootWindow.isDarkMode ? Constants.darkOverviewBackground : Constants.lightOverviewBackground
+
+            Image {
+                source: "qrc:/res/images/cyclonedds.png"
+                anchors.centerIn: parent
+                fillMode: Image.PreserveAspectFit
+                width: parent.width * 0.8
+                height: parent.height * 0.8
+            }
+        }
+
+        Rectangle {
+            Layout.preferredWidth: parent.width * 0.67
+            Layout.fillHeight: true
+            color: rootWindow.isDarkMode ? Constants.darkHeaderBackground : Constants.lightHeaderBackground
+
+            Column {
+                anchors.centerIn: parent
+                spacing: 10
+
+                Label {
+                    text: "CycloneDDS Insight"
+                    font.pixelSize: 25
+                    font.bold: true
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                Label {
+                    text: "Version: " + CYCLONEDDS_INSIGHT_VERSION
+                    font.pixelSize: 15
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                Text {
+                    text: "© 2024 Eclipse Cyclone DDS™"
+                    font.pixelSize: 10
+                    color: "#888888"
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
+        }
+    }
+}

--- a/src/views/AboutWindow.qml
+++ b/src/views/AboutWindow.qml
@@ -20,7 +20,7 @@ import org.eclipse.cyclonedds.insight
 Window {
     id: aboutWindow
 
-    property int aboutWidth: 500
+    property int aboutWidth: 550
     property int aboutHeight: 200
 
     width: aboutWidth
@@ -64,6 +64,12 @@ Window {
                 spacing: 10
 
                 Label {
+                    text: "Eclipse Cyclone DDS™"
+                    font.pixelSize: 10
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                Label {
                     text: "CycloneDDS Insight"
                     font.pixelSize: 25
                     font.bold: true
@@ -76,10 +82,9 @@ Window {
                     horizontalAlignment: Text.AlignHCenter
                 }
 
-                Text {
-                    text: "© 2024 Eclipse Cyclone DDS™"
+                Label {
+                    text: "Thanks to all contributors of the Eclipse Cyclone DDS project ❤️"
                     font.pixelSize: 10
-                    color: "#888888"
                     horizontalAlignment: Text.AlignHCenter
                 }
             }

--- a/src/views/HeaderToolBar.qml
+++ b/src/views/HeaderToolBar.qml
@@ -42,15 +42,28 @@ ToolBar {
             Layout.fillWidth: true
         }
         ToolButton {
-            text: "Home"
-            onClicked: {
-                layout.currentIndex = 1
-            }
-        }
-        ToolButton {
-            text: "Settings"
-            onClicked: {
-                layout.currentIndex = 0
+            id: menuButton
+            text: "\u2630"
+            onClicked: menu.open()
+            flat: true
+            font.pixelSize: 20
+
+            Menu {
+                id: menu
+                y: menuButton.height
+
+                MenuItem {
+                    text: "Home"
+                    onClicked: layout.currentIndex = 1
+                }
+                MenuItem {
+                    text: "Settings"
+                    onClicked: layout.currentIndex = 0
+                }
+                MenuItem {
+                    text: "About"
+                    onClicked: aboutWindow.visible = true
+                }
             }
         }
     }

--- a/src/views/HeaderToolBar.qml
+++ b/src/views/HeaderToolBar.qml
@@ -46,7 +46,7 @@ ToolBar {
             text: "\u2630"
             onClicked: menu.open()
             flat: true
-            font.pixelSize: 20
+            font.pixelSize: 15
 
             Menu {
                 id: menu

--- a/src/views/main.qml
+++ b/src/views/main.qml
@@ -15,7 +15,7 @@ import QtQuick.Window
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Dialogs
-import Qt.labs.platform
+import Qt.labs.platform as LabPlatform
 
 import org.eclipse.cyclonedds.insight
 
@@ -31,15 +31,29 @@ ApplicationWindow {
 
     header: HeaderToolBar {}
 
-    MenuBar {
-        id: menuBar
+    Loader {
+        id: nativeMenuBarLoader
+        anchors.centerIn: parent
+        sourceComponent: nativeMenuBarComponent
+        active: Qt.platform.os === "osx"
+    }
 
-        Menu {
-            title: "CycloneDDS Insight"
+    Component {
+        id: nativeMenuBarComponent
+        LabPlatform.MenuBar {
+            id: menuBar
 
-            MenuItem {
-                text: "About"
-                onTriggered: aboutWindow.visible = true
+            LabPlatform.Menu {
+                title: "Help"
+
+                LabPlatform.MenuItem {
+                    text: "About"
+                    onTriggered: aboutWindow.visible = true
+                }
+                LabPlatform.MenuItem {
+                    text: "Settings"
+                    onTriggered: layout.currentIndex = 0
+                }
             }
         }
     }

--- a/src/views/main.qml
+++ b/src/views/main.qml
@@ -15,6 +15,7 @@ import QtQuick.Window
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Dialogs
+import Qt.labs.platform
 
 import org.eclipse.cyclonedds.insight
 
@@ -29,6 +30,23 @@ ApplicationWindow {
     property bool isDarkMode: false
 
     header: HeaderToolBar {}
+
+    MenuBar {
+        id: menuBar
+
+        Menu {
+            title: "CycloneDDS Insight"
+
+            MenuItem {
+                text: "About"
+                onTriggered: aboutWindow.visible = true
+            }
+        }
+    }
+
+    AboutWindow {
+        id: aboutWindow
+    }
 
     SystemPalette {
         id: mySysPalette


### PR DESCRIPTION
This PR adds a "About Window".
The settings can now also be opened via the menu bar or `CTRL ,`

Image 1/2: Native "About CycloneDDS Insight" Buttons
<img width="362" alt="Screenshot 2024-09-25 at 22 24 56" src="https://github.com/user-attachments/assets/80245921-68f9-4963-ae75-a3c87e230499">

Image 2/2: The about dialog
<img width="1099" alt="Screenshot 2024-09-25 at 22 25 05" src="https://github.com/user-attachments/assets/92174bbb-03e3-4ebe-b8f9-be63f082412b">

@eboasson could you have a look into this PR? :)