### PR TITLE
Feature/endpoint detail window

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -35,5 +35,6 @@
         <file>src/views/ReaderTester.qml</file>
         <file>src/views/ListenerView.qml</file>
         <file>src/views/LoadingView.qml</file>
+        <file>src/views/EndpointDetailWindow.qml</file>
     </qresource>
 </RCC>

--- a/resources.qrc
+++ b/resources.qrc
@@ -20,6 +20,7 @@
         <file>res/images/spinning.gif</file>
 
         <!-- source files -->
+        <file>src/views/EndpointDetailWindow.qml</file>
         <file>src/views/main.qml</file>
         <file>src/views/AddDomainView.qml</file>
         <file>src/views/Constants.qml</file>
@@ -35,6 +36,5 @@
         <file>src/views/ReaderTester.qml</file>
         <file>src/views/ListenerView.qml</file>
         <file>src/views/LoadingView.qml</file>
-        <file>src/views/EndpointDetailWindow.qml</file>
     </qresource>
 </RCC>

--- a/src/models/datamodel_model.py
+++ b/src/models/datamodel_model.py
@@ -329,11 +329,6 @@ class DatamodelModel(QAbstractListModel):
                 max_instances=durserv_max_instances,
                 max_samples_per_instance=durserv_max_samples_per_instance))
 
-            if history == "KeepAll":
-                qos += Qos(Policy.History.KeepAll)
-            elif history == "KeepLast":
-                qos += Qos(Policy.History.KeepLast(history_keep_last_nr))
-
             logging.debug(f"add reader with qos: {str(qos)}")
 
             if domain_id in self.threads:

--- a/src/views/EndpointDetailWindow.qml
+++ b/src/views/EndpointDetailWindow.qml
@@ -25,7 +25,7 @@ Window {
     visible: false
     width: 650
     height: 450
-    flags: Qt.Dialog
+    flags: Qt.Dialog | Qt.WindowStaysOnTopHint
 
     Rectangle {
         anchors.fill: parent

--- a/src/views/EndpointDetailWindow.qml
+++ b/src/views/EndpointDetailWindow.qml
@@ -1,0 +1,49 @@
+/*
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+*/
+
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Dialogs
+
+import org.eclipse.cyclonedds.insight
+
+
+Window {
+    property string endpointText
+
+    visible: false
+    width: 650
+    height: 450
+    flags: Qt.Dialog
+
+    Rectangle {
+        anchors.fill: parent
+        color: rootWindow.isDarkMode ? Constants.darkMainContent : Constants.lightMainContent
+    }
+
+    Label {
+        id: colorLabel
+        visible: false
+    }
+
+    TextEdit {
+        anchors.fill: parent
+        text: endpointText
+        readOnly: true
+        wrapMode: Text.WordWrap
+        selectByMouse: true
+        padding: 10
+        color: colorLabel.color
+    }
+}

--- a/src/views/ReaderTester.qml
+++ b/src/views/ReaderTester.qml
@@ -278,17 +278,23 @@ Popup {
                 text: "History"
                 font.bold: true
             }
-            Row {
+            Column {
                 ComboBox {
                     id: historyComboId
                     model: ["KeepLast", "KeepAll"]
                     width: readerTesterDiaId.width - 30
                 }
-                SpinBox {
-                    id: keepLastSpinBox
-                    to: 1e9
-                    value: 1
-                    enabled: historyComboId.currentText === "KeepLast"
+                Row {
+                    Label {
+                        text: "depth"
+                        visible: historyComboId.currentText === "KeepLast"
+                    }
+                    SpinBox {
+                        id: keepLastSpinBox
+                        to: 1e9
+                        value: 1
+                        visible: historyComboId.currentText === "KeepLast"
+                    }
                 }
             }
 
@@ -621,6 +627,89 @@ Popup {
                     text: ""
                 }
             }
+
+            Label {
+                text: "DurabilityService"
+                font.bold: true
+            }
+            Column {
+                Row {
+                    Label {
+                        text: "cleanup_delay in minutes: "
+                    }
+                    SpinBox {
+                        id: cleanup_delaySpinBox
+                        to: 1e9
+                        value: 0
+                        enabled: !cleanup_delayCheckbox.checked
+                    }
+                    CheckBox {
+                        id: cleanup_delayCheckbox
+                        checked: false
+                        text: qsTr("infinite")
+                    }
+                }
+                Column {
+                    Label {
+                        text: "History"
+                    }
+                    Column {
+                        ComboBox {
+                            id: durabilityServiceHistoryComboId
+                            model: ["KeepLast", "KeepAll"]
+                            width: readerTesterDiaId.width - 30
+                        }
+                        Row {
+                            Label {
+                                text: "depth"
+                                enabled: durabilityServiceHistoryComboId.currentText === "KeepLast"
+                            }
+                            SpinBox {
+                                id: durabilityServiceKeepLastSpinBox
+                                to: 1e9
+                                value: 1
+                                enabled: durabilityServiceHistoryComboId.currentText === "KeepLast"
+                            }
+                        }
+                    }
+                    Row {
+                        Label {
+                            text: "max_samples"
+                        }
+                        SpinBox {
+                            id: durabilityServiceMaxSamplesSpinBox
+                            to: 1e9
+                            from: -1
+                            value: -1
+                        }
+                    }
+                    Row {
+                        Label {
+                            text: "max_instances"
+                        }
+                        SpinBox {
+                            id: durabilityServiceMaxInstancesSpinBox
+                            to: 1e9
+                            from: -1
+                            value: -1
+                        }
+                    }
+                    Row {
+                        Label {
+                            text: "max_samples_per_instance"
+                        }
+                        SpinBox {
+                            id: durabilityServiceMaxSamplesPerInstanceSpinBox
+                            to: 1e9
+                            from: -1
+                            value: -1
+                        }
+                    }
+                }
+            }
+
+
+
         }
     }
 
@@ -684,7 +773,13 @@ Popup {
                     propertyKeyField.text,
                     propertyValueField.text,
                     binaryPropertyKeyField.text,
-                    binaryPropertyValueField.text
+                    binaryPropertyValueField.text,
+                    cleanup_delayCheckbox.checked ? -1 : cleanup_delaySpinBox.value,
+                    durabilityServiceHistoryComboId.currentText,
+                    durabilityServiceKeepLastSpinBox.value,
+                    durabilityServiceMaxSamplesSpinBox.value,
+                    durabilityServiceMaxInstancesSpinBox.value,
+                    durabilityServiceMaxSamplesPerInstanceSpinBox.value
                 )
                 readerTesterDiaId.close()
             }

--- a/src/views/ReaderTester.qml
+++ b/src/views/ReaderTester.qml
@@ -383,12 +383,12 @@ Popup {
                 SpinBox {
                     id: latencyBudgetSpinBox
                     to: 1e9
-                    value: 2
+                    value: 0
                     enabled: !latencyBudgetCheckbox.checked
                 }
                 CheckBox {
                     id: latencyBudgetCheckbox
-                    checked: true
+                    checked: false
                     text: qsTr("infinite")
                 }
             }

--- a/src/views/TopicEndpointView.qml
+++ b/src/views/TopicEndpointView.qml
@@ -160,6 +160,13 @@ Rectangle {
                                     id: mouseAreaEndpointWriter
                                     anchors.fill: parent
                                     hoverEnabled: true
+                                    onClicked: {
+                                        if (writerEndpDetailWindow.visible) {
+                                            writerEndpDetailWindow.raise()
+                                        } else {
+                                            writerEndpDetailWindow.visible = true
+                                        }
+                                    }
                                     onEntered: {
                                         writerRec.showTooltip = true
                                     }
@@ -181,6 +188,11 @@ Rectangle {
                                         border.width: 1
                                         color: rootWindow.isDarkMode ? Constants.darkCardBackgroundColor : Constants.lightCardBackgroundColor
                                     }
+                                }
+                                EndpointDetailWindow {
+                                    id: writerEndpDetailWindow
+                                    title: "Writer " + endpoint_key
+                                    endpointText: writerTooltip.text
                                 }
                             }
                         }
@@ -246,6 +258,13 @@ Rectangle {
                                     id: mouseAreaEndpointReader
                                     anchors.fill: parent
                                     hoverEnabled: true
+                                    onClicked: {
+                                        if (readerEndpDetailWindow.visible) {
+                                            readerEndpDetailWindow.raise()
+                                        } else {
+                                            readerEndpDetailWindow.visible = true
+                                        }
+                                    }
                                     onEntered: {
                                         readerRec.showTooltip = true
                                     }
@@ -267,6 +286,11 @@ Rectangle {
                                         border.width: 1
                                         color: rootWindow.isDarkMode ? Constants.darkCardBackgroundColor : Constants.lightCardBackgroundColor
                                     }
+                                }
+                                EndpointDetailWindow {
+                                    id: readerEndpDetailWindow
+                                    title: "Reader " + endpoint_key
+                                    endpointText: readerTooltip.text
                                 }
                             }
                         }

--- a/src/views/TopicEndpointView.qml
+++ b/src/views/TopicEndpointView.qml
@@ -160,10 +160,13 @@ Rectangle {
                                     id: mouseAreaEndpointWriter
                                     anchors.fill: parent
                                     hoverEnabled: true
-                                    onClicked: {
+                                    onClicked: (mouse) => {
                                         if (writerEndpDetailWindow.visible) {
                                             writerEndpDetailWindow.raise()
                                         } else {
+                                            var globalPosition = mouseAreaEndpointWriter.mapToGlobal(mouse.x, mouse.y)
+                                            writerEndpDetailWindow.x = globalPosition.x - writerEndpDetailWindow.width / 2
+                                            writerEndpDetailWindow.y = globalPosition.y
                                             writerEndpDetailWindow.visible = true
                                         }
                                     }
@@ -258,10 +261,13 @@ Rectangle {
                                     id: mouseAreaEndpointReader
                                     anchors.fill: parent
                                     hoverEnabled: true
-                                    onClicked: {
+                                    onClicked: (mouse) => {
                                         if (readerEndpDetailWindow.visible) {
                                             readerEndpDetailWindow.raise()
                                         } else {
+                                            var globalPosition = mouseAreaEndpointReader.mapToGlobal(mouse.x, mouse.y)
+                                            readerEndpDetailWindow.x = globalPosition.x - readerEndpDetailWindow.width / 2
+                                            readerEndpDetailWindow.y = globalPosition.y
                                             readerEndpDetailWindow.visible = true
                                         }
                                     }


### PR DESCRIPTION
This PR includes:
- adds extra window for endpoint-details to better compare them
- endpoint-details windows are "always on top" to quickly open two side-by-side
- the text in endpoint-details window can be selected and copied
- the endpoint-details window opens by clicking on a endpoint
- fixes wrong LatencyBudget default value
- adds possibility to adjust DurabilityService qos
- fix out of screen history-depth-field on ubuntu
- adds dds-listener

Image of endpoint details:
![Screenshot 2024-09-27 at 21 52 42](https://github.com/user-attachments/assets/d2bfff6e-8fd1-4860-a3da-a033627b0863)

@eboasson it would be cool if you could have a look :)
