### PR TITLE
Feature/participant view

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -39,5 +39,6 @@
         <file>src/views/AboutWindow.qml</file>
         <file>src/views/CheckForUpdates.qml</file>
         <file>src/views/ParticipantsOverview.qml</file>
+        <file>src/views/SideView.qml</file>
     </qresource>
 </RCC>

--- a/resources.qrc
+++ b/resources.qrc
@@ -38,5 +38,6 @@
         <file>src/views/LoadingView.qml</file>
         <file>src/views/AboutWindow.qml</file>
         <file>src/views/CheckForUpdates.qml</file>
+        <file>src/views/ParticipantsOverview.qml</file>
     </qresource>
 </RCC>

--- a/src/dds_utils.py
+++ b/src/dds_utils.py
@@ -1,0 +1,33 @@
+"""
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+"""
+
+from typing import Optional, List
+from cyclonedds.builtin import DcpsParticipant
+from cyclonedds import core
+
+
+HOSTNAMES     = ["__Hostname",    "dds.sys_info.hostname", "fastdds.physical_data.host"]
+PROCESS_NAMES = ["__ProcessName", "dds.sys_info.executable_filepath"]
+PIDS          = ["__Pid",         "dds.sys_info.process_id", "fastdds.physical_data.process"]
+ADDRESSES     = ["__NetworkAddresses"]
+
+
+def getProperty(p: Optional[DcpsParticipant], names: List[str]):
+    propName: str = "Unknown"
+    if p is None:
+        return propName
+    for item in names:
+        if p.qos[core.Policy.Property(item, "Unknown")] is not None:
+            propName = str(p.qos[core.Policy.Property(item, "Unknown")].value)
+            if propName != "Unknown":
+                break
+    return propName

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,7 @@ import dds_data
 from models.overview_model import TreeModel, TreeNode
 from models.endpoint_model import EndpointModel
 from models.datamodel_model import DatamodelModel
+from models.participant_model import ParticipantTreeModel, ParticipantTreeNode
 import utils
 from version import CYCLONEDDS_INSIGHT_VERSION
 
@@ -87,11 +88,14 @@ if __name__ == "__main__":
 
     rootItem = TreeNode("Root")
     treeModel = TreeModel(rootItem)
+    participantRootItem = ParticipantTreeNode("Root")
+    participantModel = ParticipantTreeModel(participantRootItem)
     datamodelRepoModel = DatamodelModel()
     qmlUtils = utils.QmlUtils()
 
     engine = QQmlApplicationEngine()
     engine.rootContext().setContextProperty("treeModel", treeModel)
+    engine.rootContext().setContextProperty("participantModel", participantModel)
     engine.rootContext().setContextProperty("datamodelRepoModel", datamodelRepoModel)
     engine.rootContext().setContextProperty("qmlUtils", qmlUtils)
     engine.rootContext().setContextProperty("CYCLONEDDS_URI", os.getenv("CYCLONEDDS_URI", "<not set>"))

--- a/src/models/endpoint_model.py
+++ b/src/models/endpoint_model.py
@@ -22,13 +22,8 @@ from typing import Optional, List
 
 import dds_data
 from dds_data import DataEndpoint
+from dds_utils import getProperty, HOSTNAMES, PROCESS_NAMES, PIDS, ADDRESSES
 from utils import EntityType
-
-
-HOSTNAMES     = ["__Hostname",    "dds.sys_info.hostname", "fastdds.physical_data.host"]
-PROCESS_NAMES = ["__ProcessName", "dds.sys_info.executable_filepath"]
-PIDS          = ["__Pid",         "dds.sys_info.process_id", "fastdds.physical_data.process"]
-ADDRESSES     = ["__NetworkAddresses"]
 
 
 class EndpointModel(QAbstractItemModel):
@@ -86,17 +81,6 @@ class EndpointModel(QAbstractItemModel):
     def parent(self, index):
         return QModelIndex()
 
-    def getProperty(self, p: Optional[DcpsParticipant], names: List[str]):
-        propName: str = "Unknown"
-        if p is None:
-            return propName
-        for item in names:
-            if p.qos[core.Policy.Property(item, "Unknown")] is not None:
-                propName = str(p.qos[core.Policy.Property(item, "Unknown")].value)
-                if propName != "Unknown":
-                    break
-        return propName
-
     def data(self, index, role=Qt.DisplayRole):
         if not index.isValid() or not (0 <= index.row() < self.rowCount()):
             return None
@@ -127,14 +111,14 @@ class EndpointModel(QAbstractItemModel):
         elif role == self.TypeIdRole:
             return str(endp.type_id)
         elif role == self.HostnameRole:
-            return self.getProperty(p, HOSTNAMES)
+            return getProperty(p, HOSTNAMES)
         elif role == self.ProcessIdRole:
-            return self.getProperty(p, PIDS)
+            return getProperty(p, PIDS)
         elif role == self.ProcessNameRole:
-            appname: str = self.getProperty(p, PROCESS_NAMES)
+            appname: str = getProperty(p, PROCESS_NAMES)
             return Path(appname.replace("\\", f"{os.path.sep}")).stem
         elif role == self.AddressesRole:
-            return self.getProperty(p, ADDRESSES)
+            return getProperty(p, ADDRESSES)
         elif role == self.EndpointHasQosMismatch:
             if len(self.endpoints[endp_key].mismatches.keys()):
                 return True

--- a/src/models/overview_model.py
+++ b/src/models/overview_model.py
@@ -193,19 +193,23 @@ class TreeModel(QAbstractItemModel):
                         break
 
     @Slot(int)
-    def addDomain(self, domain_id):
+    def addDomain(self, domain_id: int):
+        # Check if the domain already exists
         for idx in range(self.rootItem.childCount()):
             child: TreeNode = self.rootItem.child(idx)
             if child.data(0) == str(domain_id):
-                return
+                return  # Domain already exists, no need to add
 
-        self.beginResetModel()
+        # Add new domain if it doesn't exist
+        row_count = self.rootItem.childCount()
+        self.beginInsertRows(QModelIndex(), row_count, row_count)
         domainChild = TreeNode(str(domain_id), True, False, self.rootItem)
         self.rootItem.appendChild(domainChild)
-        self.endResetModel()
+        self.endInsertRows()
 
     @Slot(int)
-    def removeDomain(self, domain_id):
+    def removeDomain(self, domain_id: int):
+        # Locate the domain index to remove
         dom_child_idx = -1
         for idx in range(self.rootItem.childCount()):
             child: TreeNode = self.rootItem.child(idx)
@@ -213,10 +217,11 @@ class TreeModel(QAbstractItemModel):
                 dom_child_idx = idx
                 break
 
-        if  dom_child_idx != -1:
-            self.beginResetModel()
+        # Remove the domain if it exists
+        if dom_child_idx != -1:
+            self.beginRemoveRows(QModelIndex(), dom_child_idx, dom_child_idx)
             self.rootItem.removeChild(dom_child_idx)
-            self.endResetModel()
+            self.endRemoveRows()
 
     @Slot(QModelIndex)
     def removeDomainRequest(self, indx):

--- a/src/models/overview_model.py
+++ b/src/models/overview_model.py
@@ -60,7 +60,6 @@ class TreeModel(QAbstractItemModel):
     IsDomainRole = Qt.UserRole + 1
     DisplayRole = Qt.UserRole + 2
     HasQosMismatch = Qt.UserRole + 3
-    TotalTopics = Qt.UserRole + 4
 
     remove_domain_request_signal = Signal(int)
 

--- a/src/models/overview_model.py
+++ b/src/models/overview_model.py
@@ -124,16 +124,13 @@ class TreeModel(QAbstractItemModel):
             return item.isDomain()
         if role == self.HasQosMismatch:
             return item.hasQosMismatch()
-        if role == self.TotalTopics:
-            return item.childCount()
         return None
 
     def roleNames(self):
         return {
             self.DisplayRole: b'display',
             self.IsDomainRole: b'is_domain',
-            self.HasQosMismatch: b'has_qos_mismatch',
-            self.TotalTopics: b'total_topics'
+            self.HasQosMismatch: b'has_qos_mismatch'
         }
 
     def flags(self, index):

--- a/src/models/participant_model.py
+++ b/src/models/participant_model.py
@@ -167,7 +167,7 @@ class ParticipantTreeModel(QAbstractItemModel):
 
     @Slot(int, DcpsParticipant)
     def new_participant_slot(self, domain_id: int, participant: DcpsParticipant):
-        logging.debug("New Participant " + str(participant))
+        logging.debug("New Participant " + str(participant.key))
 
         # Look for the domain_id node under rootItem
         for idx in range(self.rootItem.childCount()):

--- a/src/models/participant_model.py
+++ b/src/models/participant_model.py
@@ -31,12 +31,11 @@ class DisplayLayerEnum(Enum):
 
 
 class ParticipantTreeNode:
-    def __init__(self, data: DcpsParticipant, layer=DisplayLayerEnum.ROOT, has_qos_mismatch=False, parent=None):
+    def __init__(self, data: DcpsParticipant, layer=DisplayLayerEnum.ROOT, parent=None):
         self.parentItem = parent
         self.itemData: DcpsParticipant = data
         self.childItems = []
         self.layer: DisplayLayerEnum = layer
-        self.has_qos_mismatch = has_qos_mismatch
 
     def appendChild(self, item):
         self.childItems.append(item)
@@ -66,15 +65,11 @@ class ParticipantTreeNode:
     def isDomain(self):
         return self.layer == DisplayLayerEnum.DOMAIN
 
-    def hasQosMismatch(self):
-        return self.has_qos_mismatch
 
 class ParticipantTreeModel(QAbstractItemModel):
 
     IsDomainRole = Qt.UserRole + 1
     DisplayRole = Qt.UserRole + 2
-    HasQosMismatch = Qt.UserRole + 3
-    TotalParticipants = Qt.UserRole + 4
 
     remove_domain_request_signal = Signal(int)
 
@@ -146,18 +141,12 @@ class ParticipantTreeModel(QAbstractItemModel):
                 return ""
         if role == self.IsDomainRole:
             return item.isDomain()
-        if role == self.HasQosMismatch:
-            return item.hasQosMismatch()
-        if role == self.TotalParticipants:
-            return item.childCount()
         return None
 
     def roleNames(self):
         return {
             self.DisplayRole: b'display',
             self.IsDomainRole: b'is_domain',
-            self.HasQosMismatch: b'has_qos_mismatch',
-            self.TotalParticipants: b'total_participants'
         }
 
     def flags(self, index):
@@ -186,7 +175,7 @@ class ParticipantTreeModel(QAbstractItemModel):
                 if hostname_child is None:
                     # Insert only if the hostname does not exist
                     self.beginInsertRows(parent_index, row_count, row_count)
-                    hostname_child = ParticipantTreeNode(participant, DisplayLayerEnum.HOSTNAME, False, child)
+                    hostname_child = ParticipantTreeNode(participant, DisplayLayerEnum.HOSTNAME, child)
                     child.appendChild(hostname_child)
                     self.endInsertRows()
 
@@ -203,7 +192,7 @@ class ParticipantTreeModel(QAbstractItemModel):
                     app_row_count = hostname_child.childCount()
 
                     self.beginInsertRows(hostname_index, app_row_count, app_row_count)
-                    app_child = ParticipantTreeNode(participant, DisplayLayerEnum.APP, False, hostname_child)
+                    app_child = ParticipantTreeNode(participant, DisplayLayerEnum.APP, hostname_child)
                     hostname_child.appendChild(app_child)
                     self.endInsertRows()
 
@@ -218,7 +207,7 @@ class ParticipantTreeModel(QAbstractItemModel):
                     participant_row_count = app_child.childCount()
 
                     self.beginInsertRows(app_index, participant_row_count, participant_row_count)
-                    participant_child = ParticipantTreeNode(participant, DisplayLayerEnum.PARTICIPANT, False, app_child)
+                    participant_child = ParticipantTreeNode(participant, DisplayLayerEnum.PARTICIPANT, app_child)
                     app_child.appendChild(participant_child)
                     self.endInsertRows()
                 break
@@ -274,7 +263,7 @@ class ParticipantTreeModel(QAbstractItemModel):
         # If domain does not exist, add it
         row_count = self.rootItem.childCount()
         self.beginInsertRows(QModelIndex(), row_count, row_count)
-        domainChild = ParticipantTreeNode(str(domain_id), DisplayLayerEnum.DOMAIN, False, self.rootItem)
+        domainChild = ParticipantTreeNode(str(domain_id), DisplayLayerEnum.DOMAIN, self.rootItem)
         self.rootItem.appendChild(domainChild)
         self.endInsertRows()
 

--- a/src/views/Overview.qml
+++ b/src/views/Overview.qml
@@ -30,7 +30,6 @@ SplitView {
         implicitWidth: 350
         SplitView.minimumWidth: 50
         
-
         Rectangle {
             id: domainSplit
             color: rootWindow.isDarkMode ? Constants.darkOverviewBackground : Constants.lightOverviewBackground
@@ -38,7 +37,7 @@ SplitView {
             SplitView.minimumHeight: 50
             SplitView.fillHeight: true
 
-            TopicOverview {}
+            SideView {}
         }
 
         Rectangle {
@@ -48,12 +47,10 @@ SplitView {
             SplitView.minimumHeight: 50
             SplitView.preferredHeight: parent.height / 3
 
-            DataModelOverview {
-
-            }
+            DataModelOverview {}
         }
-
     }
+
     Rectangle {
         id: centerItem
         SplitView.minimumWidth: 50

--- a/src/views/ParticipantsOverview.qml
+++ b/src/views/ParticipantsOverview.qml
@@ -1,0 +1,104 @@
+/*
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+*/
+
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import org.eclipse.cyclonedds.insight
+
+
+TreeView {
+    id: treeView
+
+    clip: true
+    ScrollBar.vertical: ScrollBar {}
+    selectionModel: ItemSelectionModel {
+        id: treeSelection
+        onCurrentIndexChanged: {
+            console.log("Selection changed to:", currentIndex);
+            if (treeModel.getIsRowDomain(currentIndex)) {
+                stackView.clear()
+            } else {
+                //showTopicEndpointView(treeModel.getDomain(currentIndex), treeModel.getName(currentIndex))
+            }
+        }
+    }
+    model: participantModel
+
+    delegate: Item {
+        implicitWidth: domainSplit.width
+        implicitHeight: label.implicitHeight * 1.5
+
+        readonly property real indentation: 20
+        readonly property real padding: 5
+
+        // Assigned to by TreeView:
+        required property TreeView treeView
+        required property bool isTreeNode
+        required property bool expanded
+        required property int hasChildren
+        required property int depth
+        required property int row
+        required property int column
+        required property bool current
+
+        // Rotate indicator when expanded by the user
+        // (requires TreeView to have a selectionModel)
+        property Animation indicatorAnimation: NumberAnimation {
+            target: indicator
+            property: "rotation"
+            from: expanded ? 0 : 90
+            to: expanded ? 90 : 0
+            duration: 100
+            easing.type: Easing.OutQuart
+        }
+        TableView.onPooled: indicatorAnimation.complete()
+        TableView.onReused: if (current) indicatorAnimation.start()
+        onExpandedChanged: {
+            indicator.rotation = expanded ? 90 : 0
+        }
+
+        Rectangle {
+            id: background
+            anchors.fill: parent
+            visible: row === treeView.currentRow
+            color: rootWindow.isDarkMode ? Constants.darkSelectionBackground : Constants.lightSelectionBackground
+            opacity: 0.3
+        }
+
+        Label {
+            id: indicator
+            x: padding + (depth * indentation)
+            anchors.verticalCenter: parent.verticalCenter
+            visible: isTreeNode && hasChildren
+            text: "▶"
+
+            TapHandler {
+                onSingleTapped: {
+                    let index = treeView.index(row, column)
+                    treeView.selectionModel.setCurrentIndex(index, ItemSelectionModel.NoUpdate)
+                    treeView.toggleExpanded(row)
+                }
+            }
+        }
+        Label {
+            id: label
+            x: padding + (isTreeNode ? (depth + 1) * indentation : 0)
+            anchors.verticalCenter: parent.verticalCenter
+            width: parent.width - padding - x - 10
+            clip: true
+            text: model.is_domain ? "Domain " + model.display + " (" + total_participants + " Participants)" : model.display 
+        }
+    }
+}

--- a/src/views/ParticipantsOverview.qml
+++ b/src/views/ParticipantsOverview.qml
@@ -24,7 +24,7 @@ TreeView {
     clip: true
     ScrollBar.vertical: ScrollBar {}
     selectionModel: ItemSelectionModel {
-        id: treeSelection
+        id: treeSelectionParticipant
         onCurrentIndexChanged: {
             console.log("Selection changed to:", currentIndex);
             if (treeModel.getIsRowDomain(currentIndex)) {
@@ -98,7 +98,11 @@ TreeView {
             anchors.verticalCenter: parent.verticalCenter
             width: parent.width - padding - x - 10
             clip: true
-            text: model.is_domain ? "Domain " + model.display + " (" + total_participants + " Participants)" : model.display 
+            text: model.is_domain ? "Domain " + model.display : model.display 
         }
+    }
+
+    function getCurrentIndex() {
+        return treeSelectionParticipant.currentIndex
     }
 }

--- a/src/views/SideView.qml
+++ b/src/views/SideView.qml
@@ -1,0 +1,112 @@
+/*
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+*/
+
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
+
+import org.eclipse.cyclonedds.insight
+
+
+ColumnLayout {
+    anchors.fill: parent
+    spacing: 0
+
+    RowLayout {
+        spacing: 0
+
+        ComboBox {
+            id: viewSelector
+            model: ["Topic View", "Participant View"]
+            Layout.fillWidth: true
+        }
+
+        Button {
+            id: addDomainButton
+            text: "+"
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            onClicked: addDomainView.open()
+            hoverEnabled: true
+            ToolTip {
+                id: addDomainTooltip
+                parent: addDomainButton
+                visible: addDomainButton.hovered
+                delay: 200
+                text: qsTr("Add domain")
+                contentItem: Label {
+                    text: addDomainTooltip.text
+                }
+                background: Rectangle {
+                    border.color: rootWindow.isDarkMode ? Constants.darkBorderColor : Constants.lightBorderColor
+                    border.width: 1
+                    color: rootWindow.isDarkMode ? Constants.darkCardBackgroundColor : Constants.lightCardBackgroundColor
+                }
+            }
+        }
+
+        Button {
+            id: removeDomainButton
+            text: "-"
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            onClicked: {
+                if (viewSelector.currentIndex === 0) {
+                    if (treeModel.getIsRowDomain(topicOverview.getCurrentIndex())) {
+                        treeModel.removeDomainRequest(topicOverview.getCurrentIndex())
+                        stackView.clear()
+                    } else {
+                        noDomainSelectedDialog.open()
+                    }
+                } else {
+                    if (participantModel.getIsRowDomain(participantOverview.getCurrentIndex())) {
+                        participantModel.removeDomainRequest(participantOverview.getCurrentIndex())
+                        stackView.clear()
+                    } else {
+                        noDomainSelectedDialog.open()
+                    }
+                }
+            }
+            hoverEnabled: true
+            ToolTip {
+                id: removeDomainTooltip
+                parent: removeDomainButton
+                visible: removeDomainButton.hovered
+                delay: 200
+                text: qsTr("Remove the selected domain")
+                contentItem: Label {
+                    text: removeDomainTooltip.text
+                }
+                background: Rectangle {
+                    border.color: rootWindow.isDarkMode ? Constants.darkBorderColor : Constants.lightBorderColor
+                    border.width: 1
+                    color: rootWindow.isDarkMode ? Constants.darkCardBackgroundColor : Constants.lightCardBackgroundColor
+                }
+            }
+        }
+    }
+
+    TopicOverview {
+        id: topicOverview
+        visible: viewSelector.currentIndex === 0
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.leftMargin: 10
+    }
+
+    ParticipantsOverview {
+        id: participantOverview
+        visible: viewSelector.currentIndex === 1
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.leftMargin: 10
+    }
+}

--- a/src/views/TopicOverview.qml
+++ b/src/views/TopicOverview.qml
@@ -25,13 +25,12 @@ ColumnLayout {
     RowLayout {
         spacing: 0
 
-        Label {
-            text: "Overview"
-            Layout.leftMargin: 10
-        }
-        Item {
+        ComboBox {
+            id: viewSelector
+            model: ["Topic View", "Participant View"]
             Layout.fillWidth: true
         }
+
         Button {
             id: addDomainButton
             text: "+"
@@ -85,10 +84,10 @@ ColumnLayout {
             }
         }
     }
-    
 
     TreeView {
         id: treeView
+        visible: viewSelector.currentIndex === 0
         Layout.fillWidth: true
         Layout.fillHeight: true
         Layout.leftMargin: 10
@@ -169,7 +168,7 @@ ColumnLayout {
                 anchors.verticalCenter: parent.verticalCenter
                 width: parent.width - padding - x - 10
                 clip: true
-                text: model.is_domain ? "Domain " + model.display : model.display 
+                text: model.is_domain ? "Domain " + model.display + " (" + total_topics + " Topics)": model.display 
             }
 
             WarningTriangle {
@@ -184,5 +183,12 @@ ColumnLayout {
                 tooltipText: "Qos mismatch detected."
             }
         }
+    }
+
+    ParticipantsOverview {
+        visible: viewSelector.currentIndex === 1
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        Layout.leftMargin: 10
     }
 }

--- a/src/views/TopicOverview.qml
+++ b/src/views/TopicOverview.qml
@@ -18,177 +18,107 @@ import QtQuick.Layouts
 import org.eclipse.cyclonedds.insight
 
 
-ColumnLayout {
-    anchors.fill: parent
-    spacing: 0
-
-    RowLayout {
-        spacing: 0
-
-        ComboBox {
-            id: viewSelector
-            model: ["Topic View", "Participant View"]
-            Layout.fillWidth: true
-        }
-
-        Button {
-            id: addDomainButton
-            text: "+"
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            onClicked: addDomainView.open()
-            hoverEnabled: true
-            ToolTip {
-                id: addDomainTooltip
-                parent: addDomainButton
-                visible: addDomainButton.hovered
-                delay: 200
-                text: qsTr("Add domain")
-                contentItem: Label {
-                    text: addDomainTooltip.text
-                }
-                background: Rectangle {
-                    border.color: rootWindow.isDarkMode ? Constants.darkBorderColor : Constants.lightBorderColor
-                    border.width: 1
-                    color: rootWindow.isDarkMode ? Constants.darkCardBackgroundColor : Constants.lightCardBackgroundColor
-                }
-            }
-        }
-
-        Button {
-            id: removeDomainButton
-            text: "-"
-            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-            onClicked: {
-                if (treeModel.getIsRowDomain(treeSelection.currentIndex)) {
-                    treeModel.removeDomainRequest(treeSelection.currentIndex)
-                    stackView.clear()
-                } else {
-                    noDomainSelectedDialog.open()
-                }
-            }
-            hoverEnabled: true
-            ToolTip {
-                id: removeDomainTooltip
-                parent: removeDomainButton
-                visible: removeDomainButton.hovered
-                delay: 200
-                text: qsTr("Remove the selected domain")
-                contentItem: Label {
-                    text: removeDomainTooltip.text
-                }
-                background: Rectangle {
-                    border.color: rootWindow.isDarkMode ? Constants.darkBorderColor : Constants.lightBorderColor
-                    border.width: 1
-                    color: rootWindow.isDarkMode ? Constants.darkCardBackgroundColor : Constants.lightCardBackgroundColor
-                }
+TreeView {
+    id: treeView
+    visible: viewSelector.currentIndex === 0
+    Layout.fillWidth: true
+    Layout.fillHeight: true
+    Layout.leftMargin: 10
+    clip: true
+    ScrollBar.vertical: ScrollBar {}
+    selectionModel: ItemSelectionModel {
+        id: treeSelection
+        onCurrentIndexChanged: {
+            console.log("Selection changed to:", currentIndex);
+            if (treeModel.getIsRowDomain(currentIndex)) {
+                stackView.clear()
+            } else {
+                showTopicEndpointView(treeModel.getDomain(currentIndex), treeModel.getName(currentIndex))
             }
         }
     }
+    model: treeModel
 
-    TreeView {
-        id: treeView
-        visible: viewSelector.currentIndex === 0
-        Layout.fillWidth: true
-        Layout.fillHeight: true
-        Layout.leftMargin: 10
-        clip: true
-        ScrollBar.vertical: ScrollBar {}
-        selectionModel: ItemSelectionModel {
-            id: treeSelection
-            onCurrentIndexChanged: {
-                console.log("Selection changed to:", currentIndex);
-                if (treeModel.getIsRowDomain(currentIndex)) {
-                    stackView.clear()
-                } else {
-                    showTopicEndpointView(treeModel.getDomain(currentIndex), treeModel.getName(currentIndex))
+    delegate: Item {
+        implicitWidth: domainSplit.width
+        implicitHeight: label.implicitHeight * 1.5
+
+        readonly property real indentation: 20
+        readonly property real padding: 5
+
+        // Assigned to by TreeView:
+        required property TreeView treeView
+        required property bool isTreeNode
+        required property bool expanded
+        required property int hasChildren
+        required property int depth
+        required property int row
+        required property int column
+        required property bool current
+
+        // Rotate indicator when expanded by the user
+        // (requires TreeView to have a selectionModel)
+        property Animation indicatorAnimation: NumberAnimation {
+            target: indicator
+            property: "rotation"
+            from: expanded ? 0 : 90
+            to: expanded ? 90 : 0
+            duration: 100
+            easing.type: Easing.OutQuart
+        }
+        TableView.onPooled: indicatorAnimation.complete()
+        TableView.onReused: if (current) indicatorAnimation.start()
+        onExpandedChanged: {
+            indicator.rotation = expanded ? 90 : 0
+        }
+
+        Rectangle {
+            id: background
+            anchors.fill: parent
+            visible: row === treeView.currentRow
+            color: rootWindow.isDarkMode ? Constants.darkSelectionBackground : Constants.lightSelectionBackground
+            opacity: 0.3
+        }
+
+        Label {
+            id: indicator
+            x: padding + (depth * indentation)
+            anchors.verticalCenter: parent.verticalCenter
+            visible: isTreeNode && hasChildren
+            text: "▶"
+
+            TapHandler {
+                onSingleTapped: {
+                    let index = treeView.index(row, column)
+                    treeView.selectionModel.setCurrentIndex(index, ItemSelectionModel.NoUpdate)
+                    treeView.toggleExpanded(row)
                 }
             }
         }
-        model: treeModel
+        Label {
+            id: label
+            x: padding + (isTreeNode ? (depth + 1) * indentation : 0)
+            anchors.verticalCenter: parent.verticalCenter
+            width: parent.width - padding - x - 10
+            clip: true
+            text: model.is_domain ? "Domain " + model.display : model.display 
+        }
 
-        delegate: Item {
-            implicitWidth: domainSplit.width
-            implicitHeight: label.implicitHeight * 1.5
-
-            readonly property real indentation: 20
-            readonly property real padding: 5
-
-            // Assigned to by TreeView:
-            required property TreeView treeView
-            required property bool isTreeNode
-            required property bool expanded
-            required property int hasChildren
-            required property int depth
-            required property int row
-            required property int column
-            required property bool current
-
-            // Rotate indicator when expanded by the user
-            // (requires TreeView to have a selectionModel)
-            property Animation indicatorAnimation: NumberAnimation {
-                target: indicator
-                property: "rotation"
-                from: expanded ? 0 : 90
-                to: expanded ? 90 : 0
-                duration: 100
-                easing.type: Easing.OutQuart
-            }
-            TableView.onPooled: indicatorAnimation.complete()
-            TableView.onReused: if (current) indicatorAnimation.start()
-            onExpandedChanged: {
-                indicator.rotation = expanded ? 90 : 0
-            }
-
-            Rectangle {
-                id: background
-                anchors.fill: parent
-                visible: row === treeView.currentRow
-                color: rootWindow.isDarkMode ? Constants.darkSelectionBackground : Constants.lightSelectionBackground
-                opacity: 0.3
-            }
-
-            Label {
-                id: indicator
-                x: padding + (depth * indentation)
-                anchors.verticalCenter: parent.verticalCenter
-                visible: isTreeNode && hasChildren
-                text: "▶"
-
-                TapHandler {
-                    onSingleTapped: {
-                        let index = treeView.index(row, column)
-                        treeView.selectionModel.setCurrentIndex(index, ItemSelectionModel.NoUpdate)
-                        treeView.toggleExpanded(row)
-                    }
-                }
-            }
-            Label {
-                id: label
-                x: padding + (isTreeNode ? (depth + 1) * indentation : 0)
-                anchors.verticalCenter: parent.verticalCenter
-                width: parent.width - padding - x - 10
-                clip: true
-                text: model.is_domain ? "Domain " + model.display + " (" + total_topics + " Topics)": model.display 
-            }
-
-            WarningTriangle {
-                id: warning_triangle
-                visible: model.has_qos_mismatch
-                width: 15
-                height: 15
-                anchors.verticalCenter: label.verticalCenter
-                anchors.right: model.is_domain ? label.right : label.left
-                anchors.margins: 5
-                enableTooltip: true
-                tooltipText: "Qos mismatch detected."
-            }
+        WarningTriangle {
+            id: warning_triangle
+            visible: model.has_qos_mismatch
+            width: 15
+            height: 15
+            anchors.verticalCenter: label.verticalCenter
+            anchors.right: model.is_domain ? label.right : label.left
+            anchors.margins: 5
+            enableTooltip: true
+            tooltipText: "Qos mismatch detected."
         }
     }
 
-    ParticipantsOverview {
-        visible: viewSelector.currentIndex === 1
-        Layout.fillWidth: true
-        Layout.fillHeight: true
-        Layout.leftMargin: 10
+    function getCurrentIndex() {
+        return treeSelection.currentIndex
     }
 }
+


### PR DESCRIPTION
This PR adds a participant view in addition to the topic view.
You can see participants and their related hostname, process-name and pid.
Tree organized by Domain/hostname/process:pid/participant-key.

1. Select topic view:
<img width="355" alt="Screenshot 2024-10-29 at 22 18 11" src="https://github.com/user-attachments/assets/f49a63c1-aa43-4691-9b68-10089fd55326">

2. Check participants
<img width="1212" alt="Screenshot 2024-10-29 at 22 17 55" src="https://github.com/user-attachments/assets/4fd50d6c-37ca-4909-8fd3-b497b45329ea">

@eboasson could you have a look?
