### PR TITLE
Feature/partition-matching-handling

### DIFF
--- a/src/dds_qos.py
+++ b/src/dds_qos.py
@@ -306,23 +306,21 @@ def partition_patmatch_p(pat, name):
         return ddsi_patmatch(pat, name)
 
 def partitions_match_default(x):
-    if qos.Policy.Partition not in x or len(x[qos.Policy.Partition].partitions) == 0:
+    if len(x) == 0:
         return True
-    for i in range(len(x[qos.Policy.Partition].partitions)):
-        if partition_patmatch_p(x[qos.Policy.Partition].partitions[i], ""):
+    for i in x:
+        if partition_patmatch_p(i, ""):
             return True
     return False
 
 def partitions_match_p(a, b):
-    if (qos.Policy.Partition not in a) or len(a[qos.Policy.Partition].partitions) == 0:
+    if len(a) == 0:
         return partitions_match_default(b)
-    elif (qos.Policy.Partition not in b) or len(b[qos.Policy.Partition].partitions) == 0:
+    elif len(b) == 0:
         return partitions_match_default(a)
     else:
-        for i in range(len(a[qos.Policy.Partition].partitions)):
-            for j in range(len(b[qos.Policy.Partition].partitions)):
-                if (partition_patmatch_p(a[qos.Policy.Partition].partitions[i], b[qos.Policy.Partition].partitions[j]) or 
-                        partition_patmatch_p(b[qos.Policy.Partition].partitions[j], a[qos.Policy.Partition].partitions[i])):
+        for i in a:
+            for j in b:
+                if (partition_patmatch_p(i, j) or partition_patmatch_p(j, i)):
                     return True
         return False
-

--- a/src/dds_qos.py
+++ b/src/dds_qos.py
@@ -78,9 +78,6 @@ def qos_match(endpoint_reader, endpoint_writer) -> list:
     if destination_order_rd and destination_order_wr and destination_order_rd > destination_order_wr:
         mismatches.append(dds_qos_policy_id.DDS_DESTINATIONORDER_QOS_POLICY_ID)
 
-    if not partitions_match_p(endpoint_reader.qos, endpoint_writer.qos):
-        mismatches.append(dds_qos_policy_id.DDS_PARTITION_QOS_POLICY_ID)
-
     if qos.Policy.DataRepresentation in endpoint_reader.qos and qos.Policy.DataRepresentation in endpoint_writer.qos:
         if endpoint_writer.qos[qos.Policy.DataRepresentation].use_cdrv0_representation and endpoint_reader.qos[qos.Policy.DataRepresentation].use_cdrv0_representation:
             pass # ok - both using cdrv0

--- a/src/dds_service.py
+++ b/src/dds_service.py
@@ -147,7 +147,11 @@ class DdsListener(core.Listener):
         logging.warning("on_sample_rejected")
 
     def on_requested_incompatible_qos(self, reader, status):
-        logging.warning(f"on_requested_incompatible_qos: {dds_qos_policy_id(status.last_policy_id).name}")
+        # QoS mismatches are not worthy of a warning (they should not have been a QoS in DDS in the first place)
+        # Most likely a mismatch is intended, otherwise there is no reason to use partitions.
+        # We show matching partitions inside the gui to be able to verify them.
+        if dds_qos_policy_id(status.last_policy_id) != dds_qos_policy_id.DDS_PARTITION_QOS_POLICY_ID:
+            logging.warning(f"on_requested_incompatible_qos: {dds_qos_policy_id(status.last_policy_id).name}")
 
     def on_publication_matched(self, writer, status):
         logging.debug("on_publication_matched")

--- a/src/models/endpoint_model.py
+++ b/src/models/endpoint_model.py
@@ -107,8 +107,7 @@ class EndpointModel(QAbstractItemModel):
     EndpointQosMismatchText = Qt.UserRole + 12
     AddressesRole = Qt.UserRole + 13
     PartitionsRole  = Qt.UserRole + 14
-    MatchedPartitionsRole  = Qt.UserRole + 15
-    HasPartitionsRole = Qt.UserRole + 16
+    HasPartitionsRole = Qt.UserRole + 15
 
     topicHasQosMismatchSignal = Signal(bool)
     totalEndpointsSignal = Signal(int)
@@ -256,6 +255,7 @@ class EndpointModel(QAbstractItemModel):
     @Slot()
     def clearPartitionMatching(self):
         self.selectedPartition = None
+        self.selectedPartitionEndpKey = ""
         for endp_key in list(self.endpoints.keys()):
             self.partitions[endp_key].clearMatching()
 

--- a/src/views/TopicEndpointView.qml
+++ b/src/views/TopicEndpointView.qml
@@ -151,7 +151,7 @@ Rectangle {
                         }
 
                         delegate: Item {
-                            height: 65
+                            height: 85
                             width: listViewWriter.width
 
                             Rectangle {
@@ -252,8 +252,9 @@ Rectangle {
                         }
 
                         delegate: Item {
-                            height: 65
+                            height: 85
                             width: listViewReader.width
+                            z: 10
 
                             Rectangle {
                                 anchors.fill: parent
@@ -261,25 +262,9 @@ Rectangle {
                                 border.color: endpoint_has_qos_mismatch ? Constants.warningColor : rootWindow.isDarkMode ? Constants.darkBorderColor : Constants.lightBorderColor
                                 border.width: 0.5
                                 id: readerRec
+                                
                                 property bool showTooltip: false
 
-                                Column {
-                                    spacing: 0
-                                    padding: 10
-
-                                    Label {
-                                        text: endpoint_key
-                                        font.pixelSize: 14
-                                    }
-                                    Label {
-                                        text: endpoint_process_name + ":" + endpoint_process_id + "@" + endpoint_hostname
-                                        font.pixelSize: 12
-                                    }
-                                    Label {
-                                        text: addresses
-                                        font.pixelSize: 8
-                                    }
-                                }
                                 MouseArea {
                                     id: mouseAreaEndpointReader
                                     anchors.fill: parent
@@ -301,6 +286,77 @@ Rectangle {
                                         readerRec.showTooltip = false
                                     }
                                 }
+
+                                Column {
+                                    spacing: 0
+                                    padding: 10
+
+                                    Label {
+                                        text: endpoint_key
+                                        font.pixelSize: 14
+                                    }
+                                    Label {
+                                        text: endpoint_process_name + ":" + endpoint_process_id + "@" + endpoint_hostname
+                                        font.pixelSize: 12
+                                    }
+                                    Label {
+                                        text: addresses
+                                        font.pixelSize: 8
+                                    }
+                                    Item {
+                                        height: 5
+                                        width: 1
+                                    }
+                                    Flickable {
+                                        width: listViewReader.width - 20
+                                        contentWidth: rowContent.width
+                                        height: 20
+                                        clip: true
+
+                                        Row {
+                                            id: rowContent
+                                            spacing: 10
+                                            Repeater {
+                                                model: ["PartitionA", "PartitionB", "Partition*", "SomethingOtherDIfferent"]
+                                                Rectangle {
+                                                    z: 100
+                                                    height: 20
+                                                    radius: 5
+                                                    color: rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
+                                                    border.color: "black"
+                                                    border.width: 1
+                                                    width: textItem.width + 20
+
+                                                    Text {
+                                                        id: textItem
+                                                        anchors.centerIn: parent
+                                                        text: modelData
+                                                        font.pixelSize: 12
+                                                    }
+
+                                                    MouseArea {
+                                                        id: partitionMouseArea
+                                                        hoverEnabled: true
+                                                        
+                                                        anchors.fill: parent
+                                                        onPressed: {
+                                                        }
+                                                        onReleased: {
+                                                        }
+
+                                                        onClicked: (mouse) => {
+                                                            console.log("clicked partition " + modelData)
+                                                        }
+                                                        onEntered: {
+                                                            readerRec.showTooltip = true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
                                 ToolTip {
                                     id: readerTooltip
                                     parent: readerRec

--- a/src/views/TopicEndpointView.qml
+++ b/src/views/TopicEndpointView.qml
@@ -210,7 +210,7 @@ Rectangle {
                                     }
                                     Label {
                                         text: "(No Partition)"
-                                        visible: partitions.length === 0
+                                        visible: has_partitions === false
                                         font.pixelSize: 12
                                     }
                                     Flickable {
@@ -218,7 +218,7 @@ Rectangle {
                                         contentWidth: rowContent.width
                                         height: 20
                                         clip: true
-                                        visible: partitions.length !== 0
+                                        visible: has_partitions === true
 
                                         Row {
                                             id: rowContent
@@ -227,48 +227,34 @@ Rectangle {
                                                 model: partitions
                                                 Rectangle {
                                                     id: partitionRectangle
-                                                    property bool isMatching: false
                                                     z: 100
                                                     height: 20
                                                     radius: 5
-                                                    color: isMatching ? "green" : rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
-                                                    border.color: isMatching ? "green" : "black"
+                                                    color: partition_matched ? "#009600" : rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
+                                                    border.color: partition_matched ? "#009600" : "black"
                                                     border.width: 1
                                                     width: textItem.width + 20
-
-                                                    Connections {
-                                                        target: endpointWriterModel
-                                                        function onMatchedPartitionsSignal(matchedPartitionNames) {
-                                                            if (matchedPartitionNames.indexOf(modelData) !== -1) {
-                                                                partitionRectangle.isMatching = true
-                                                            } else {
-                                                                partitionRectangle.isMatching = false
-                                                            }
-                                                        }
-                                                    }
 
                                                     Label {
                                                         id: textItem
                                                         anchors.centerIn: parent
-                                                        text: modelData
+                                                        text: partition_name
                                                         font.pixelSize: 12
                                                     }
 
                                                     MouseArea {
                                                         id: partitionMouseArea
                                                         hoverEnabled: true
-                                                        
+                                                        cursorShape: Qt.PointingHandCursor                                  
                                                         anchors.fill: parent
-                                                        onPressed: {  
-
-                                                        }
-                                                        onReleased: {
-
-                                                        }
-
                                                         onClicked: (mouse) => {
-                                                            endpointReaderModel.setSelectedPartition(modelData)
-                                                            endpointWriterModel.setSelectedPartition(modelData)
+                                                            if (partition_matched) {
+                                                                endpointReaderModel.clearPartitionMatching()
+                                                                endpointWriterModel.clearPartitionMatching()
+                                                            } else {
+                                                                endpointReaderModel.setSelectedPartition(partition_name)
+                                                                endpointWriterModel.setSelectedPartition(partition_name)
+                                                            }
                                                         }
                                                         onEntered: {
                                                             writerRec.showTooltip = true
@@ -389,7 +375,7 @@ Rectangle {
                                     }
                                     Label {
                                         text: "(No Partition)"
-                                        visible: partitions.length === 0
+                                        visible: has_partitions === false
                                         font.pixelSize: 12
                                     }
                                     Flickable {
@@ -397,7 +383,7 @@ Rectangle {
                                         contentWidth: rowContent.width
                                         height: 20
                                         clip: true
-                                        visible: partitions.length !== 0
+                                        visible: has_partitions === true
 
                                         Row {
                                             id: rowContent
@@ -406,48 +392,35 @@ Rectangle {
                                                 model: partitions
                                                 Rectangle {
                                                     id: partitionRectangle
-                                                    property bool isMatching: false
+        
                                                     z: 100
                                                     height: 20
                                                     radius: 5
-                                                    color: isMatching ? "green" : rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
-                                                    border.color: isMatching ? "green" : "black"
+                                                    color: partition_matched ? "#009600" : rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
+                                                    border.color: partition_matched ? "#009600" : "black"
                                                     border.width: 1
                                                     width: textItem.width + 20
-
-
-
-                                                    Connections {
-                                                        target: endpointReaderModel
-                                                        function onMatchedPartitionsSignal(matchedPartitionNames) {
-                                                            if (matchedPartitionNames.indexOf(modelData) !== -1) {
-                                                                partitionRectangle.isMatching = true
-                                                            } else {
-                                                                partitionRectangle.isMatching = false
-                                                            }
-                                                        }
-                                                    }
 
                                                     Label {
                                                         id: textItem
                                                         anchors.centerIn: parent
-                                                        text: modelData
+                                                        text: partition_name
                                                         font.pixelSize: 12
                                                     }
 
                                                     MouseArea {
                                                         id: partitionMouseArea
                                                         hoverEnabled: true
-                                                        
+                                                        cursorShape: Qt.PointingHandCursor
                                                         anchors.fill: parent
-                                                        onPressed: {
-                                                        }
-                                                        onReleased: {
-                                                        }
-
                                                         onClicked: (mouse) => {
-                                                            endpointReaderModel.setSelectedPartition(modelData)
-                                                            endpointWriterModel.setSelectedPartition(modelData)
+                                                            if (partition_matched) {
+                                                                endpointReaderModel.clearPartitionMatching()
+                                                                endpointWriterModel.clearPartitionMatching()
+                                                            } else {
+                                                                endpointReaderModel.setSelectedPartition(partition_name)
+                                                                endpointWriterModel.setSelectedPartition(partition_name)
+                                                            }
                                                         }
                                                         onEntered: {
                                                             readerRec.showTooltip = true

--- a/src/views/TopicEndpointView.qml
+++ b/src/views/TopicEndpointView.qml
@@ -231,8 +231,8 @@ Rectangle {
                                                     height: 20
                                                     radius: 5
                                                     color: partition_matched ? "#009600" : rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
-                                                    border.color: partition_matched ? "#009600" : "black"
-                                                    border.width: 1
+                                                    border.color: partition_selected ? "orange" : partition_matched ? "#009600" : "black"
+                                                    border.width: partition_selected ? 2 : 1
                                                     width: textItem.width + 20
 
                                                     Label {
@@ -248,12 +248,12 @@ Rectangle {
                                                         cursorShape: Qt.PointingHandCursor                                  
                                                         anchors.fill: parent
                                                         onClicked: (mouse) => {
-                                                            if (partition_matched) {
+                                                            if (partition_selected) {
                                                                 endpointReaderModel.clearPartitionMatching()
                                                                 endpointWriterModel.clearPartitionMatching()
                                                             } else {
-                                                                endpointReaderModel.setSelectedPartition(partition_name)
-                                                                endpointWriterModel.setSelectedPartition(partition_name)
+                                                                endpointReaderModel.setSelectedPartition(partition_name, "")
+                                                                endpointWriterModel.setSelectedPartition(partition_name, endpoint_key)
                                                             }
                                                         }
                                                         onEntered: {
@@ -397,8 +397,8 @@ Rectangle {
                                                     height: 20
                                                     radius: 5
                                                     color: partition_matched ? "#009600" : rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
-                                                    border.color: partition_matched ? "#009600" : "black"
-                                                    border.width: 1
+                                                    border.color: partition_selected ? "orange" : partition_matched ? "#009600" : "black"
+                                                    border.width: partition_selected ? 2 : 1
                                                     width: textItem.width + 20
 
                                                     Label {
@@ -414,12 +414,12 @@ Rectangle {
                                                         cursorShape: Qt.PointingHandCursor
                                                         anchors.fill: parent
                                                         onClicked: (mouse) => {
-                                                            if (partition_matched) {
+                                                            if (partition_selected) {
                                                                 endpointReaderModel.clearPartitionMatching()
                                                                 endpointWriterModel.clearPartitionMatching()
                                                             } else {
-                                                                endpointReaderModel.setSelectedPartition(partition_name)
-                                                                endpointWriterModel.setSelectedPartition(partition_name)
+                                                                endpointReaderModel.setSelectedPartition(partition_name, endpoint_key)
+                                                                endpointWriterModel.setSelectedPartition(partition_name, "")
                                                             }
                                                         }
                                                         onEntered: {

--- a/src/views/TopicEndpointView.qml
+++ b/src/views/TopicEndpointView.qml
@@ -150,6 +150,8 @@ Rectangle {
                             policy: ScrollBar.AsNeeded
                         }
 
+                        property int lastPartitionPressedIndex: -1
+
                         delegate: Item {
                             height: 85
                             width: listViewWriter.width
@@ -162,23 +164,8 @@ Rectangle {
                                 color: rootWindow.isDarkMode ? mouseAreaEndpointWriter.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : mouseAreaEndpointWriter.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
                                 border.color: endpoint_has_qos_mismatch ? Constants.warningColor : rootWindow.isDarkMode ? Constants.darkBorderColor : Constants.lightBorderColor
                                 border.width: 0.5
-                                Column {
-                                    spacing: 0
-                                    padding: 10
 
-                                    Label {
-                                        text: endpoint_key
-                                        font.pixelSize: 14
-                                    }
-                                    Label {
-                                        text: endpoint_process_name + ":" + endpoint_process_id + "@" + endpoint_hostname
-                                        font.pixelSize: 12
-                                    }
-                                    Label {
-                                        text: addresses
-                                        font.pixelSize: 8
-                                    }
-                                }
+
                                 MouseArea {
                                     id: mouseAreaEndpointWriter
                                     anchors.fill: parent
@@ -200,6 +187,99 @@ Rectangle {
                                         writerRec.showTooltip = false
                                     }
                                 }
+
+                                Column {
+                                    spacing: 0
+                                    padding: 10
+
+                                    Label {
+                                        text: endpoint_key
+                                        font.pixelSize: 14
+                                    }
+                                    Label {
+                                        text: endpoint_process_name + ":" + endpoint_process_id + "@" + endpoint_hostname
+                                        font.pixelSize: 12
+                                    }
+                                    Label {
+                                        text: addresses
+                                        font.pixelSize: 8
+                                    }
+                                    Item {
+                                        height: 5
+                                        width: 1
+                                    }
+                                    Label {
+                                        text: "(No Partition)"
+                                        visible: partitions.length === 0
+                                        font.pixelSize: 12
+                                    }
+                                    Flickable {
+                                        width: listViewReader.width - 20
+                                        contentWidth: rowContent.width
+                                        height: 20
+                                        clip: true
+                                        visible: partitions.length !== 0
+
+                                        Row {
+                                            id: rowContent
+                                            spacing: 10
+                                            Repeater {
+                                                model: partitions
+                                                Rectangle {
+                                                    id: partitionRectangle
+                                                    property bool isMatching: false
+                                                    z: 100
+                                                    height: 20
+                                                    radius: 5
+                                                    color: isMatching ? "green" : rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
+                                                    border.color: isMatching ? "green" : "black"
+                                                    border.width: 1
+                                                    width: textItem.width + 20
+
+                                                    Connections {
+                                                        target: endpointWriterModel
+                                                        function onMatchedPartitionsSignal(matchedPartitionNames) {
+                                                            if (matchedPartitionNames.indexOf(modelData) !== -1) {
+                                                                partitionRectangle.isMatching = true
+                                                            } else {
+                                                                partitionRectangle.isMatching = false
+                                                            }
+                                                        }
+                                                    }
+
+                                                    Label {
+                                                        id: textItem
+                                                        anchors.centerIn: parent
+                                                        text: modelData
+                                                        font.pixelSize: 12
+                                                    }
+
+                                                    MouseArea {
+                                                        id: partitionMouseArea
+                                                        hoverEnabled: true
+                                                        
+                                                        anchors.fill: parent
+                                                        onPressed: {  
+
+                                                        }
+                                                        onReleased: {
+
+                                                        }
+
+                                                        onClicked: (mouse) => {
+                                                            endpointReaderModel.setSelectedPartition(modelData)
+                                                            endpointWriterModel.setSelectedPartition(modelData)
+                                                        }
+                                                        onEntered: {
+                                                            writerRec.showTooltip = true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
                                 ToolTip {
                                     id: writerTooltip
                                     parent: writerRec
@@ -307,27 +387,48 @@ Rectangle {
                                         height: 5
                                         width: 1
                                     }
+                                    Label {
+                                        text: "(No Partition)"
+                                        visible: partitions.length === 0
+                                        font.pixelSize: 12
+                                    }
                                     Flickable {
                                         width: listViewReader.width - 20
                                         contentWidth: rowContent.width
                                         height: 20
                                         clip: true
+                                        visible: partitions.length !== 0
 
                                         Row {
                                             id: rowContent
                                             spacing: 10
                                             Repeater {
-                                                model: ["PartitionA", "PartitionB", "Partition*", "SomethingOtherDIfferent"]
+                                                model: partitions
                                                 Rectangle {
+                                                    id: partitionRectangle
+                                                    property bool isMatching: false
                                                     z: 100
                                                     height: 20
                                                     radius: 5
-                                                    color: rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
-                                                    border.color: "black"
+                                                    color: isMatching ? "green" : rootWindow.isDarkMode ? partitionMouseArea.pressed ? Constants.darkPressedColor : Constants.darkCardBackgroundColor : partitionMouseArea.pressed ? Constants.lightPressedColor : Constants.lightCardBackgroundColor
+                                                    border.color: isMatching ? "green" : "black"
                                                     border.width: 1
                                                     width: textItem.width + 20
 
-                                                    Text {
+
+
+                                                    Connections {
+                                                        target: endpointReaderModel
+                                                        function onMatchedPartitionsSignal(matchedPartitionNames) {
+                                                            if (matchedPartitionNames.indexOf(modelData) !== -1) {
+                                                                partitionRectangle.isMatching = true
+                                                            } else {
+                                                                partitionRectangle.isMatching = false
+                                                            }
+                                                        }
+                                                    }
+
+                                                    Label {
                                                         id: textItem
                                                         anchors.centerIn: parent
                                                         text: modelData
@@ -345,7 +446,8 @@ Rectangle {
                                                         }
 
                                                         onClicked: (mouse) => {
-                                                            console.log("clicked partition " + modelData)
+                                                            endpointReaderModel.setSelectedPartition(modelData)
+                                                            endpointWriterModel.setSelectedPartition(modelData)
                                                         }
                                                         onEntered: {
                                                             readerRec.showTooltip = true


### PR DESCRIPTION
This PR closes #30

- No qos-mismatch-warning are shown anymore for partitions
- Partitions are shown inside the topic view
- By clicking on a partition all the matching partitions are shown

Thanks a lot to @hansvanthag for the input.

This is how it looks:
- Matching partitions have a green background
- The selected partition additionally has a orange border
<img width="1382" alt="Screenshot 2024-12-26 at 08 32 22" src="https://github.com/user-attachments/assets/95a71045-3757-4ee3-8085-02a3304d6561" />


@eboasson could you have a look?