### PR TITLE
feature/fix-hostname-for-fastdds

### DIFF
--- a/src/dds_access/dds_utils.py
+++ b/src/dds_access/dds_utils.py
@@ -42,6 +42,16 @@ def getProperty(p: Optional[DcpsParticipant], names: List[str]):
     return propName
 
 
+def getHostname(p: Optional[DcpsParticipant]):
+    hostnameRaw = getProperty(p, HOSTNAMES)
+    hostname = hostnameRaw
+    if ":" in hostnameRaw:
+        hostnameSplit = hostnameRaw.split(":")
+        if len(hostnameSplit) > 0:
+            hostname = hostnameSplit[0]
+    return hostname
+
+
 def getConfiguredDomainIds():
 
     def expandEnvVariable(value):

--- a/src/dds_access/dds_utils.py
+++ b/src/dds_access/dds_utils.py
@@ -44,12 +44,11 @@ def getProperty(p: Optional[DcpsParticipant], names: List[str]):
 
 def getHostname(p: Optional[DcpsParticipant]):
     hostnameRaw = getProperty(p, HOSTNAMES)
-    hostname = hostnameRaw
     if ":" in hostnameRaw:
         hostnameSplit = hostnameRaw.split(":")
         if len(hostnameSplit) > 0:
-            hostname = hostnameSplit[0]
-    return hostname
+            return hostnameSplit[0]
+    return hostnameRaw
 
 
 def getConfiguredDomainIds():

--- a/src/dds_access/dds_utils.py
+++ b/src/dds_access/dds_utils.py
@@ -23,7 +23,7 @@ import re
 
 
 HOSTNAMES     = ["__Hostname",    "dds.sys_info.hostname", "fastdds.physical_data.host"]
-PROCESS_NAMES = ["__ProcessName", "dds.sys_info.executable_filepath"]
+PROCESS_NAMES = ["__ProcessName", "dds.sys_info.executable_filepath", "fastdds.application.id"]
 PIDS          = ["__Pid",         "dds.sys_info.process_id", "fastdds.physical_data.process"]
 ADDRESSES     = ["__NetworkAddresses"]
 

--- a/src/models/endpoint_model.py
+++ b/src/models/endpoint_model.py
@@ -23,7 +23,7 @@ from typing import Optional, List
 
 from dds_access import dds_data
 from dds_access.dds_data import DataEndpoint
-from dds_access.dds_utils import getProperty, HOSTNAMES, PROCESS_NAMES, PIDS, ADDRESSES
+from dds_access.dds_utils import getProperty, getHostname, PROCESS_NAMES, PIDS, ADDRESSES
 from dds_access.dds_qos import partitions_match_p
 from dds_access.datatypes.entity_type import EntityType
 
@@ -182,7 +182,7 @@ class EndpointModel(QAbstractItemModel):
         elif role == self.TypeIdRole:
             return str(endp.type_id)
         elif role == self.HostnameRole:
-            return getProperty(p, HOSTNAMES)
+            return getHostname(p)
         elif role == self.ProcessIdRole:
             return getProperty(p, PIDS)
         elif role == self.ProcessNameRole:

--- a/src/models/participant_model.py
+++ b/src/models/participant_model.py
@@ -19,7 +19,7 @@ from typing import List
 from cyclonedds.builtin import DcpsParticipant
 from loguru import logger as logging
 from dds_access import dds_data
-from dds_access.dds_utils import getProperty, HOSTNAMES, PROCESS_NAMES, PIDS, ADDRESSES
+from dds_access.dds_utils import getProperty, getHostname, PROCESS_NAMES, PIDS, ADDRESSES
 from enum import Enum
 
 
@@ -168,7 +168,7 @@ class ParticipantTreeModel(QAbstractItemModel):
                 return item.data(index)
             elif item.layer == DisplayLayerEnum.HOSTNAME:
                 p = item.data(index)
-                return getProperty(p, HOSTNAMES)
+                return getHostname(p)
             elif item.layer == DisplayLayerEnum.APP:
                 p = item.data(index)
                 return getAppName(getProperty(p, PROCESS_NAMES), getProperty(p, PIDS))
@@ -213,7 +213,7 @@ class ParticipantTreeModel(QAbstractItemModel):
         logging.trace("Add Participant " + str(participant.key) + " to participant model")
 
         # Look for the domain_id node under rootItem
-        hostname = getProperty(participant, HOSTNAMES)
+        hostname = getHostname(participant)
         appName = getAppName(getProperty(participant, PROCESS_NAMES), getProperty(participant, PIDS))
 
         if domain_id in self.rootItem.childMap:
@@ -228,7 +228,7 @@ class ParticipantTreeModel(QAbstractItemModel):
             else:
                 self.beginInsertRows(parent_index, row_count, row_count)
                 hostname_child = ParticipantTreeNode(participant, DisplayLayerEnum.HOSTNAME, domain_child)
-                domain_child.appendChild(getProperty(participant, HOSTNAMES), hostname_child)
+                domain_child.appendChild(getHostname(participant), hostname_child)
                 self.endInsertRows()
         
             # Add app
@@ -375,7 +375,7 @@ class ParticipantTreeModel(QAbstractItemModel):
     @Slot(str, int, dds_data.DataEndpoint)
     def new_endpoint_slot(self, unkown: str, domain_id: int, participant: dds_data.DataEndpoint):
 
-        hostname = getProperty(participant.participant, HOSTNAMES)
+        hostname = getHostname(participant.participant)
         appName = getAppName(getProperty(participant.participant, PROCESS_NAMES), getProperty(participant.participant, PIDS))
 
         if domain_id in self.rootItem.childMap:


### PR DESCRIPTION
This PR fixes the hostname for some fastdds participants. It seems that they are sometimes split by colon.
```
DcpsParticipant(
    key=UUID('010f5b27-3c2f-78fb-0000-0000000001c1'),
    qos=Qos(
        Policy.EntityName(name='monitor_domain_0'),
        Policy.Liveliness.Automatic(lease_duration=20000000000), 
        Property(key="PARTICIPANT_TYPE", value="SIMPLE"),
        Property(key="__NetworkAddresses", value="udp/192.168.0.139:7410@14"),
        Property(key="fastdds.application.id", value="FASTDDS_MONITOR"),
        Property(key="fastdds.application.metadata", value=""),
        Property(key="fastdds.physical_data.host", value="trittsv-desktop:195807744721944576"), 
        Property(key="fastdds.physical_data.process", value="12092"),
        Property(key="fastdds.physical_data.user", value="sven")
    )
)
```
@eboasson could you have a look? :)