### PR TITLE
feature/shape-demo-placeholder-shapes-for-reader-and-writer

### DIFF
--- a/src/models/shapes_demo_model.py
+++ b/src/models/shapes_demo_model.py
@@ -308,7 +308,7 @@ class ShapeDispatcherThread(QThread):
                         if not self.running:
                             break
 
-                        instance_handle = sample.color
+                        instance_handle = str(sample.sample_info.instance_handle)
                         if instance_handle in count_per_instance:
                             count_per_instance[instance_handle] += 1
                         else:

--- a/src/models/shapes_demo_model.py
+++ b/src/models/shapes_demo_model.py
@@ -211,7 +211,7 @@ class ShapeDynamicThread(QThread):
         self.rotationSpeed = rotationSpeed
         self.fillKind = ishape.ShapeFillKind(fillKind)
         self.dataType = ishape.ShapeTypeExtended
-        self.id = f"{self.shapeType}_{self.color}_0"
+        self.id = str(uuid.uuid4())
 
     def run(self):
         self.running = True

--- a/src/views/shapes_demo/ShapesDemoCircle.qml
+++ b/src/views/shapes_demo/ShapesDemoCircle.qml
@@ -23,8 +23,9 @@ Item {
     id: root
     property real rotation: 0
     property color color: "lightgray"
-    property string orientation: ""
+    property color centerColor: "black"
     property bool isHatch: false
+    property string orientation: ""
     property int hatchSpacing: 7
     property int lineWidth: 2
     property real borderWidth: 1
@@ -87,6 +88,13 @@ Item {
             ctx.beginPath()
             ctx.arc(centerX, centerY, radius - root.borderWidth / 2, 0, 2 * Math.PI)
             ctx.stroke()
+
+            // Inner circle
+            ctx.fillStyle = root.centerColor
+            const innerRadius = radius / 3
+            ctx.beginPath()
+            ctx.arc(centerX, centerY, innerRadius, 0, 2 * Math.PI)
+            ctx.fill()
         }
 
         onWidthChanged: requestPaint()

--- a/src/views/shapes_demo/ShapesDemoCircle.qml
+++ b/src/views/shapes_demo/ShapesDemoCircle.qml
@@ -30,6 +30,9 @@ Item {
     property int lineWidth: 2
     property real borderWidth: 1
     property color borderColor: rootWindow.isDarkMode ? "darkgray" : "black"
+    property bool isForeground: true
+
+    z: isForeground ? 1 : 0
 
     Canvas {
         id: canvas

--- a/src/views/shapes_demo/ShapesDemoSquare.qml
+++ b/src/views/shapes_demo/ShapesDemoSquare.qml
@@ -31,6 +31,9 @@ Item {
     property int spacing: 7
     property color borderColor: rootWindow.isDarkMode ? "darkgray" : "black"
     property bool isCircle: false
+    property bool isForeground: true
+
+    z: isForeground ? 1 : 0
 
     Canvas {
         id: rectangleCanvas

--- a/src/views/shapes_demo/ShapesDemoSquare.qml
+++ b/src/views/shapes_demo/ShapesDemoSquare.qml
@@ -25,6 +25,7 @@ Item {
     height: 50
 
     property color color: "blue"
+    property color centerColor: "black"
     property bool isHatch: false
     property string orientation: ""
     property int spacing: 7
@@ -81,6 +82,17 @@ Item {
                 ctx.stroke();
                 ctx.restore();
             }
+
+            // Draw inner rectangle (half size)
+            const innerWidth = width / 3;
+            const innerHeight = height / 3;
+            const innerX = (width - innerWidth) / 2;
+            const innerY = (height - innerHeight) / 2;
+
+            ctx.beginPath();
+            ctx.rect(innerX, innerY, innerWidth, innerHeight);
+            ctx.fillStyle = rectangleItem.centerColor;  // reusing this property
+            ctx.fill();
         }
 
         onWidthChanged: requestPaint()

--- a/src/views/shapes_demo/ShapesDemoTriangle.qml
+++ b/src/views/shapes_demo/ShapesDemoTriangle.qml
@@ -28,7 +28,9 @@ Item {
     property real rotation: 0
     property real borderWidth: 1
     property color borderColor: rootWindow.isDarkMode ? "darkgray" : "black"
+    property bool isForeground: true
 
+    z: isForeground ? 1 : 0
     onRotationChanged: triangleCanvas.requestPaint()
 
     Canvas {

--- a/src/views/shapes_demo/ShapesDemoTriangle.qml
+++ b/src/views/shapes_demo/ShapesDemoTriangle.qml
@@ -24,6 +24,7 @@ Item {
     property color color: "blue"
     property string orientation: ""
     property bool isHatch: false
+    property color centerColor: "black"
     property real rotation: 0
     property real borderWidth: 1
     property color borderColor: rootWindow.isDarkMode ? "darkgray" : "black"
@@ -90,9 +91,16 @@ Item {
                 ctx.restore()
             }
 
+            // Dot in the center
+            const radius = triangleHeight / (3 * Math.sqrt(3));
+            const centroidY = triangleHeight / 6;
+            ctx.beginPath();
+            ctx.arc(0, centroidY, radius, 0, 2 * Math.PI);
+            ctx.fillStyle = triangleItem.centerColor;
+            ctx.fill();
+
             ctx.restore()
         }
-
 
         onWidthChanged: requestPaint()
         onHeightChanged: requestPaint()

--- a/src/views/shapes_demo/ShapesDemoView.qml
+++ b/src/views/shapes_demo/ShapesDemoView.qml
@@ -35,7 +35,6 @@ Window {
 
     Component.onCompleted: {
         shapesMap = {};
-        pendingWriterMap = {};
     }
 
     Connections {
@@ -43,10 +42,6 @@ Window {
         function onShapeUpdateSignale(id, shape, color, x, y, size, rotation, fillKind, disposed, fromDds) {
 
             if (shapeDemoViewId.paused) {
-                return
-            }
-
-            if (handlePendingWriter(id, fromDds) === false) {
                 return
             }
 
@@ -71,7 +66,7 @@ Window {
                 if (disposed) {
                     console.log("Shape with ID", id, "was disposed");
                 } else {
-                    spawnShape(id, shape, x, y, realSize, pastelColorToQColor(realColor, opacity), rotation, fillKind, centerColor);
+                    spawnShape(id, shape, x, y, realSize, pastelColorToQColor(realColor, opacity), rotation, fillKind, centerColor, !fromDds);
                 }
             } else {
                 if (disposed) { 
@@ -89,25 +84,7 @@ Window {
         delete shapesMap[id];
     }
 
-    function handlePendingWriter(id, fromDds) {
-        if (pendingWriterMap[id] === undefined) {
-            if (fromDds === true) {
-                pendingWriterMap[id] = true
-            } else {
-                pendingWriterMap[id] = false
-            }
-        } else {
-            if (fromDds === true && pendingWriterMap[id] === false)  {
-                destroyShape(id)
-                pendingWriterMap[id] = true
-            } else if (fromDds === false && pendingWriterMap[id] === true) {
-                return false
-            } 
-        }
-        return true
-    }
-
-    function spawnShape(shapeId, shape, initX, initY, initSize, color, rotation, fillKind, centerColor) {
+    function spawnShape(shapeId, shape, initX, initY, initSize, color, rotation, fillKind, centerColor, isForeground) {
         var rect = null;
         var isHatch = fillKind > 1;
         var orientation = "";
@@ -122,7 +99,7 @@ Window {
                 console.error("Failed to load ShapesDemoCircle.qml:", circleComponent.errorString());
                 return;
             }
-            rect = circleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor });
+            rect = circleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor, isForeground: isForeground });
         } else if (shape === "Triangle") {
             var realSize = initSize * (2-shapeDemoViewId.triangleScale);
             var triangleComponent = Qt.createComponent("qrc:/src/views/shapes_demo/ShapesDemoTriangle.qml");
@@ -130,14 +107,14 @@ Window {
                 console.error("Failed to load ShapesDemoTriangle.qml:", circleComponent.errorString());
                 return;
             }
-            rect = triangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: realSize, height: realSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor });
+            rect = triangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: realSize, height: realSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor, isForeground: isForeground });
         } else {
             var rectangleComponent = Qt.createComponent("qrc:/src/views/shapes_demo/ShapesDemoSquare.qml");
             if (rectangleComponent.status !== Component.Ready) {
                 console.error("Failed to load ShapesDemoSquare.qml:", circleComponent.errorString());
                 return;
             }
-            rect = rectangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor });
+            rect = rectangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor, isForeground: isForeground });
         }
         if (rect !== null) {
             shapesMap[shapeId] = rect;

--- a/src/views/shapes_demo/ShapesDemoView.qml
+++ b/src/views/shapes_demo/ShapesDemoView.qml
@@ -29,15 +29,27 @@ Window {
     minimumHeight: 400
     flags: Qt.Window
     property var shapesMap
+    property var pendingWriterMap
     property var triangleScale: 0.7
+    property bool paused: false
 
     Component.onCompleted: {
         shapesMap = {};
+        pendingWriterMap = {};
     }
 
     Connections {
         target: shapesDemoModel
-        function onShapeUpdateSignale(id, shape, color, x, y, size, rotation, fillKind, disposed) {
+        function onShapeUpdateSignale(id, shape, color, x, y, size, rotation, fillKind, disposed, fromDds) {
+
+            if (shapeDemoViewId.paused) {
+                return
+            }
+
+            if (handlePendingWriter(id, fromDds) === false) {
+                return
+            }
+
             var realSize = size;
             if (shape === "Triangle") {
                 realSize = size * (2-shapeDemoViewId.triangleScale);
@@ -48,17 +60,23 @@ Window {
                 realColor = "transparent";
             }
 
+            var opacity = 1.0
+            var centerColor = "black"
+            if (!fromDds) {
+                opacity = 0.5
+                centerColor = "white"
+            }
+
             if (shapesMap[id] === undefined) {
                 if (disposed) {
                     console.log("Shape with ID", id, "was disposed");
                 } else {
-                    spawnShape(id, shape, x, y, realSize, pastelColor(realColor), rotation, fillKind);
+                    spawnShape(id, shape, x, y, realSize, pastelColorToQColor(realColor, opacity), rotation, fillKind, centerColor);
                 }
             } else {
                 if (disposed) { 
                     console.log("Shape with ID", id, "was disposed");
-                    shapesMap[id].destroy();
-                    delete shapesMap[id];
+                    destroyShape(id)
                 } else {
                     moveShape(id, x, y, realSize, rotation);
                 }
@@ -66,7 +84,30 @@ Window {
         }
     }
 
-    function spawnShape(shapeId, shape, initX, initY, initSize, color, rotation, fillKind) {
+    function destroyShape(id) {
+        shapesMap[id].destroy();
+        delete shapesMap[id];
+    }
+
+    function handlePendingWriter(id, fromDds) {
+        if (pendingWriterMap[id] === undefined) {
+            if (fromDds === true) {
+                pendingWriterMap[id] = true
+            } else {
+                pendingWriterMap[id] = false
+            }
+        } else {
+            if (fromDds === true && pendingWriterMap[id] === false)  {
+                destroyShape(id)
+                pendingWriterMap[id] = true
+            } else if (fromDds === false && pendingWriterMap[id] === true) {
+                return false
+            } 
+        }
+        return true
+    }
+
+    function spawnShape(shapeId, shape, initX, initY, initSize, color, rotation, fillKind, centerColor) {
         var rect = null;
         var isHatch = fillKind > 1;
         var orientation = "";
@@ -81,7 +122,7 @@ Window {
                 console.error("Failed to load ShapesDemoCircle.qml:", circleComponent.errorString());
                 return;
             }
-            rect = circleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch });
+            rect = circleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor });
         } else if (shape === "Triangle") {
             var realSize = initSize * (2-shapeDemoViewId.triangleScale);
             var triangleComponent = Qt.createComponent("qrc:/src/views/shapes_demo/ShapesDemoTriangle.qml");
@@ -89,14 +130,14 @@ Window {
                 console.error("Failed to load ShapesDemoTriangle.qml:", circleComponent.errorString());
                 return;
             }
-            rect = triangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: realSize, height: realSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch });
+            rect = triangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: realSize, height: realSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor });
         } else {
             var rectangleComponent = Qt.createComponent("qrc:/src/views/shapes_demo/ShapesDemoSquare.qml");
             if (rectangleComponent.status !== Component.Ready) {
                 console.error("Failed to load ShapesDemoSquare.qml:", circleComponent.errorString());
                 return;
             }
-            rect = rectangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch });
+            rect = rectangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor });
         }
         if (rect !== null) {
             shapesMap[shapeId] = rect;
@@ -352,7 +393,31 @@ Window {
                     id: shapesPlane
                     color: rootWindow.isDarkMode ? "black" : "white"
                     Layout.fillWidth: true
-                    Layout.fillHeight: true                    
+                    Layout.fillHeight: true
+
+                    Button {
+                        id: pauseButton
+                        text: shapeDemoViewId.paused ? "\u23F5" : "\u23F8"
+                        anchors.top: parent.top
+                        anchors.right: parent.right
+                        anchors.margins: 10
+                    }
+
+                    Label {
+                        text: "Paused"
+                        visible: shapeDemoViewId.paused
+                        anchors.top: parent.top
+                        anchors.right: pauseButton.left
+                        font.pixelSize: 24
+                        anchors.margins: 10
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            shapeDemoViewId.paused = !shapeDemoViewId.paused
+                        }
+                    }               
                 }
             }
         }
@@ -412,6 +477,9 @@ Window {
             return "#99CCFF";
         case "gray":
             return "#999999";
+        case "lightgray":
+        case "light grey":
+            return "#CCCCCC";
         case "black":
             return "#333333";
         case "purple":
@@ -421,6 +489,28 @@ Window {
         default:
             return "#333333"; // fallback to black
         }
+    }
+
+    function hexToRgb(hex) {
+        if (hex === "transparent") {
+            return { r: 0, g: 0, b: 0, a: 0 };
+        }
+        hex = hex.replace("#", "");
+        const bigint = parseInt(hex, 16);
+        return {
+            r: (bigint >> 16) & 255,
+            g: (bigint >> 8) & 255,
+            b: bigint & 255
+        };
+    }
+
+    function pastelColorToQColor(name, opacity = 1.0) {
+        const hex = pastelColor(name);
+        const rgb = hexToRgb(hex);
+        if (name === "transparent") {
+            return rgb;
+        }
+        return Qt.rgba(rgb.r / 255, rgb.g / 255, rgb.b / 255, opacity);
     }
 
     QosSelector {

--- a/src/views/shapes_demo/ShapesDemoView.qml
+++ b/src/views/shapes_demo/ShapesDemoView.qml
@@ -61,19 +61,28 @@ Window {
                 opacity = 0.5
                 centerColor = "white"
             }
+            var rgbaColor = pastelColorToQColor(realColor, opacity)
+
+            var isHatch = fillKind > 1;
+            var orientation = "";
+            if (fillKind === 2) {
+                orientation = "horizontal";
+            } else if (fillKind === 3) {
+                orientation = "vertical";
+            }
 
             if (shapesMap[id] === undefined) {
                 if (disposed) {
                     console.log("Shape with ID", id, "was disposed");
                 } else {
-                    spawnShape(id, shape, x, y, realSize, pastelColorToQColor(realColor, opacity), rotation, fillKind, centerColor, !fromDds);
+                    spawnShape(id, shape, x, y, realSize, rgbaColor, rotation, centerColor, !fromDds, orientation, isHatch);
                 }
             } else {
                 if (disposed) { 
                     console.log("Shape with ID", id, "was disposed");
                     destroyShape(id)
                 } else {
-                    moveShape(id, x, y, realSize, rotation);
+                    updateShape(id, x, y, realSize, rotation, rgbaColor, orientation, isHatch); 
                 }
             }
         }
@@ -84,15 +93,8 @@ Window {
         delete shapesMap[id];
     }
 
-    function spawnShape(shapeId, shape, initX, initY, initSize, color, rotation, fillKind, centerColor, isForeground) {
+    function spawnShape(shapeId, shape, initX, initY, initSize, color, rotation, centerColor, isForeground, orientation, isHatch) {
         var rect = null;
-        var isHatch = fillKind > 1;
-        var orientation = "";
-        if (fillKind === 2) {
-            orientation = "horizontal";
-        } else if (fillKind === 3) {
-            orientation = "vertical";
-        }
         if (shape === "Circle") {
             var circleComponent = Qt.createComponent("qrc:/src/views/shapes_demo/ShapesDemoCircle.qml");
             if (circleComponent.status !== Component.Ready) {
@@ -101,13 +103,12 @@ Window {
             }
             rect = circleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor, isForeground: isForeground });
         } else if (shape === "Triangle") {
-            var realSize = initSize * (2-shapeDemoViewId.triangleScale);
             var triangleComponent = Qt.createComponent("qrc:/src/views/shapes_demo/ShapesDemoTriangle.qml");
             if (triangleComponent.status !== Component.Ready) {
                 console.error("Failed to load ShapesDemoTriangle.qml:", circleComponent.errorString());
                 return;
             }
-            rect = triangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: realSize, height: realSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor, isForeground: isForeground });
+            rect = triangleComponent.createObject(shapesPlane, { x: initX, y: initY, width: initSize, height: initSize, color: color, rotation: rotation, orientation: orientation, isHatch: isHatch, centerColor: centerColor, isForeground: isForeground });
         } else {
             var rectangleComponent = Qt.createComponent("qrc:/src/views/shapes_demo/ShapesDemoSquare.qml");
             if (rectangleComponent.status !== Component.Ready) {
@@ -121,13 +122,16 @@ Window {
         }
     }
 
-    function moveShape(id, newX, newY, newSize, rotation) {
+    function updateShape(id, newX, newY, newSize, rotation, color, orientation, isHatch) {
         if (shapesMap && shapesMap[id] !== undefined) {
             shapesMap[id].x = newX;
             shapesMap[id].y = newY;
             shapesMap[id].height = newSize;
             shapesMap[id].width = newSize;
             shapesMap[id].rotation = rotation;
+            shapesMap[id].color = color;
+            shapesMap[id].orientation = orientation;
+            shapesMap[id].isHatch = isHatch;
         } else {
             console.log("Shape with ID", id, "not found!");
         }

--- a/src/views/shapes_demo/ShapesDemoView.qml
+++ b/src/views/shapes_demo/ShapesDemoView.qml
@@ -372,21 +372,11 @@ Window {
                     Layout.fillWidth: true
                     Layout.fillHeight: true
 
-                    Button {
-                        id: pauseButton
-                        text: shapeDemoViewId.paused ? "►" : "❚❚"
-                        anchors.top: parent.top
-                        anchors.right: parent.right
-                        anchors.margins: 10
-                        width: 40
-                        height: 40
-                    }
-
                     Label {
                         text: "Paused"
                         visible: shapeDemoViewId.paused
                         anchors.top: parent.top
-                        anchors.right: pauseButton.left
+                        anchors.right: parent.right
                         font.pixelSize: 24
                         anchors.margins: 10
                     }

--- a/src/views/shapes_demo/ShapesDemoView.qml
+++ b/src/views/shapes_demo/ShapesDemoView.qml
@@ -374,7 +374,7 @@ Window {
 
                     Button {
                         id: pauseButton
-                        text: shapeDemoViewId.paused ? "\u23F5" : "\u23F8"
+                        text: shapeDemoViewId.paused ? "►" : "❚❚"
                         anchors.top: parent.top
                         anchors.right: parent.right
                         anchors.margins: 10

--- a/src/views/shapes_demo/ShapesDemoView.qml
+++ b/src/views/shapes_demo/ShapesDemoView.qml
@@ -378,6 +378,8 @@ Window {
                         anchors.top: parent.top
                         anchors.right: parent.right
                         anchors.margins: 10
+                        width: 40
+                        height: 40
                     }
 
                     Label {


### PR DESCRIPTION
This PR adds the following features to the shapes demo:
- centered black dot indicating that the shape is from a dds reader.
- centered white dot indicating that the shape is from local writer.
- a light grey shape for reader which not received any data yet.
- click on panel to pause the shapes


<img width="801" alt="Screenshot 2025-05-21 at 19 40 23" src="https://github.com/user-attachments/assets/f40a038f-bcba-4275-a6f1-04c120031c4f" />


@eboasson could you have a look?