### PR TITLE
fix qos handling for shapes and general writer

### DIFF
--- a/src/dds_access/dispatcher.py
+++ b/src/dds_access/dispatcher.py
@@ -76,7 +76,7 @@ class DispatcherThread(QThread):
     def addEndpoint(self, id: str, topic_name: str, topic_type, qos, entity_type: EntityType):
         logging.info(f"Add endpoint {id} ...")
         try:
-            topic = Topic(self.domain_participant, topic_name, topic_type, qos=qos, listener=self.listener)
+            topic = Topic(self.domain_participant, topic_name, topic_type, listener=self.listener)
 
             if entity_type == EntityType.READER:
                 subscriber = Subscriber(self.domain_participant, qos=qos, listener=self.listener)

--- a/src/models/shapes_demo_model.py
+++ b/src/models/shapes_demo_model.py
@@ -216,7 +216,7 @@ class ShapeDynamicThread(QThread):
     def run(self):
         self.running = True
         try:
-            topic = Topic(self.domain_participant, self.shapeType, self.dataType, self.qos)
+            topic = Topic(self.domain_participant, self.shapeType, self.dataType)
             publisher = Publisher(self.domain_participant, self.qos)
             writer = DataWriter(publisher, topic, self.qos)
             shape = ishape.ShapeTypeExtended(self.color, 0, 0, self.size, self.fillKind, self.rotation)
@@ -288,7 +288,7 @@ class ShapeDispatcherThread(QThread):
         placeholderVisible: bool = True
 
         try:
-            topic = Topic(self.domain_participant, self.topic_name, self.topic_type, self.qos)
+            topic = Topic(self.domain_participant, self.topic_name, self.topic_type)
             subscriber = Subscriber(self.domain_participant, self.qos)
             reader = DataReader(subscriber, topic, self.qos)
 


### PR DESCRIPTION
This PR fixes a bug where it was not possible to create two endpoints with different qos (in shapes and general reader/writer).

@eboasson could you have a look?