### PR TITLE
ci update windows runner to 2022

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
         image: ubuntu-22.04
       'macOS_13_x64':
         image: macOS-13
-      'Windows_Server_2019_x64':
-        image: windows-2019
+      'Windows_Server_2022_x64':
+        image: windows-2022
   steps:
     - template: /.azure/templates/build-insight.yml


### PR DESCRIPTION
This PR updates the deprecated `windows-2019` runner to `windows-2022`.

@eboasson could you have a look?