### PR TITLE
update qt to 6.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PySide6==6.8.0
+PySide6==6.9.1
 pyinstaller==6.10.0
 loguru==0.7.3
 requests==2.32.3


### PR DESCRIPTION
This PR updates qt to version 6.9.1.

It solves a bug in insight where switching manually between white and dark-mode did not work on ubuntu.

@eboasson could you have a look?