### PR TITLE
Feature/search-topics

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -43,7 +43,9 @@ from PySide6.QtQuickControls2 import QQuickStyle
 from loguru import logger as logging
 from dds_access import dds_data
 from dds_access.dds_utils import getConfiguredDomainIds
-from models.overview_model import TreeModel, TreeNode
+from models.overview_model.tree_filter_proxy_model import TreeFilterProxyModel
+from models.overview_model.tree_model import TreeModel
+from models.overview_model.tree_node import TreeNode
 from models.endpoint_model import EndpointModel
 from models.datamodel_model import DatamodelModel
 from models.tester_model import TesterModel
@@ -101,6 +103,9 @@ if __name__ == "__main__":
 
     rootItem = TreeNode("Root")
     treeModel = TreeModel(rootItem)
+    filterTreeModel = TreeFilterProxyModel()
+    filterTreeModel.setSourceModel(treeModel)
+
     threads = {}
     dataModelHandler: DataModelHandler = DataModelHandler()
     datamodelRepoModel = DatamodelModel(threads, dataModelHandler)
@@ -114,6 +119,7 @@ if __name__ == "__main__":
     app.aboutToQuit.connect(qmlUtils.aboutToQuit)
 
     engine = QQmlApplicationEngine()
+    engine.rootContext().setContextProperty("treeModelProxy", filterTreeModel)
     engine.rootContext().setContextProperty("treeModel", treeModel)
     engine.rootContext().setContextProperty("participantModel", participantModel)
     engine.rootContext().setContextProperty("datamodelRepoModel", datamodelRepoModel)

--- a/src/models/overview_model/tree_filter_proxy_model.py
+++ b/src/models/overview_model/tree_filter_proxy_model.py
@@ -1,0 +1,86 @@
+"""
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+"""
+
+from PySide6.QtCore import Qt, QModelIndex, QAbstractItemModel, Qt, QSortFilterProxyModel
+from PySide6.QtCore import Signal, Slot
+from loguru import logger as logging
+from dds_access import dds_data
+from dds_access.domain_finder import DomainFinder
+from models.overview_model.tree_model import TreeModel
+
+
+class TreeFilterProxyModel(QSortFilterProxyModel):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._filter = ""
+
+    @Slot(result=QAbstractItemModel)
+    def getSourceModel(self):
+        return self.sourceModel()
+
+    @Slot(str)
+    def setFilter(self, text):
+        self._filter = text
+        self.invalidateFilter()
+
+    def filterAcceptsRow(self, source_row, source_parent):
+        model = self.sourceModel()
+        index = model.index(source_row, 0, source_parent)
+        return self.filterAcceptsIndex(index)
+
+    def filterAcceptsIndex(self, index):
+        model = self.sourceModel()
+        if not index.isValid():
+            return False
+
+        if self._filter.lower() in model.data(index, TreeModel.DisplayRole).lower():
+            return True
+
+        for i in range(model.rowCount(index)):
+            if self.filterAcceptsIndex(model.index(i, 0, index)):
+                return True
+
+        return False
+
+    @Slot(QModelIndex, result=bool)
+    def getIsRowTopic(self, index: QModelIndex):
+        if not index.isValid():
+            return False
+        source_index = self.mapToSource(index)
+        return self.sourceModel().getIsRowTopic(source_index)
+
+    @Slot(QModelIndex, result=bool)
+    def getIsRowDomain(self, index: QModelIndex):
+        if not index.isValid():
+            return False
+        source_index = self.mapToSource(index)
+        return self.sourceModel().getIsRowDomain(source_index)
+
+    @Slot(QModelIndex, result=int)
+    def getDomain(self, index: QModelIndex):
+        if not index.isValid():
+            return None
+        source_index = self.mapToSource(index)
+        return self.sourceModel().getDomain(source_index)
+
+    @Slot(QModelIndex, result=str)
+    def getName(self, index: QModelIndex):
+        if not index.isValid():
+            return ""
+        source_index = self.mapToSource(index)
+        return self.sourceModel().getName(source_index)
+
+    @Slot(QModelIndex)
+    def removeDomainRequest(self, index: QModelIndex):
+        if not index.isValid():
+            return
+        self.sourceModel()._removeDomainRequest(self.mapToSource(index))

--- a/src/models/overview_model/tree_node.py
+++ b/src/models/overview_model/tree_node.py
@@ -1,0 +1,60 @@
+"""
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+"""
+
+from PySide6.QtCore import Qt, QModelIndex, QAbstractItemModel, Qt, QSortFilterProxyModel
+from PySide6.QtCore import Signal, Slot
+from loguru import logger as logging
+from dds_access import dds_data
+from dds_access.domain_finder import DomainFinder
+
+
+class TreeNode:
+    def __init__(self, data: str, is_domain=False, has_qos_mismatch=False, parent=None):
+        self.parentItem = parent
+        self.itemData = data
+        self.childItems = []
+        self.is_domain = is_domain
+        self.has_qos_mismatch = has_qos_mismatch
+
+    def appendChild(self, item):
+        self.childItems.append(item)
+
+    def child(self, row):
+        return self.childItems[row]
+
+    def childCount(self):
+        return len(self.childItems)
+
+    def columnCount(self):
+        return 1
+
+    def data(self, column):
+        return self.itemData
+
+    def parent(self):
+        return self.parentItem
+    def row(self):
+        if self.parentItem:
+            return self.parentItem.childItems.index(self)
+        return 0
+
+    def removeChild(self, row):
+        del self.childItems[row]
+
+    def isDomain(self):
+        return self.is_domain
+
+    def isTopic(self):
+        return not self.is_domain
+
+    def hasQosMismatch(self):
+        return self.has_qos_mismatch

--- a/src/views/SideView.qml
+++ b/src/views/SideView.qml
@@ -74,8 +74,8 @@ ColumnLayout {
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
             onClicked: {
                 if (viewSelector.currentIndex === 0) {
-                    if (treeModel.getIsRowDomain(topicOverview.getCurrentIndex())) {
-                        treeModel.removeDomainRequest(topicOverview.getCurrentIndex())
+                    if (treeModelProxy.getIsRowDomain(topicOverview.getCurrentIndex())) {
+                        treeModelProxy.removeDomainRequest(topicOverview.getCurrentIndex())
                         stackView.clear()
                     } else {
                         noDomainSelectedDialog.open()
@@ -106,14 +106,48 @@ ColumnLayout {
                 }
             }
         }
+        Button {
+            text: "\u{1F50D}"
+            flat: true
+            highlighted: searchField.visible
+            visible: viewSelector.currentIndex === 0
+            Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            onClicked: {
+                if (viewSelector.currentIndex === 0) {
+                    if (searchField.visible) {
+                        searchField.visible = false
+                        searchField.text = ""
+                    } else {
+                        searchField.visible = true
+                    }
+                }
+            }
+        }
     }
 
-    TopicOverview {
-        id: topicOverview
+    ColumnLayout {
         visible: viewSelector.currentIndex === 0
-        Layout.fillWidth: true
-        Layout.fillHeight: true
-        Layout.leftMargin: 10
+        spacing: 0
+        TextField {
+            id: searchField
+            placeholderText: "Search Topic Name ..."
+            visible: false
+            Layout.fillWidth: true
+            onTextChanged: {
+                treeModelProxy.setFilter(searchField.text)
+            }
+            Layout.leftMargin: 10
+            Layout.rightMargin: 10
+            Layout.bottomMargin: 5
+
+        }
+
+        TopicOverview {
+            id: topicOverview
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.leftMargin: 10
+        }
     }
 
     ParticipantsOverview {

--- a/src/views/SideView.qml
+++ b/src/views/SideView.qml
@@ -122,6 +122,8 @@ ColumnLayout {
                     }
                 }
             }
+            Layout.preferredWidth: Qt.platform.os === "osx" ? 50 : 30
+            Layout.preferredHeight: Qt.platform.os === "osx" ? 30 : 24
         }
     }
 

--- a/src/views/TopicOverview.qml
+++ b/src/views/TopicOverview.qml
@@ -30,17 +30,17 @@ TreeView {
         id: treeSelection
         onCurrentIndexChanged: {
             console.log("Selection changed to:", currentIndex);
-            if (treeModel.getIsRowDomain(currentIndex)) {
-                showDomainView(treeModel.getDomain(currentIndex))
-            } else if (treeModel.getIsRowTopic(currentIndex)) {
-                showTopicEndpointView(treeModel.getDomain(currentIndex), treeModel.getName(currentIndex))
+            if (treeModelProxy.getIsRowDomain(currentIndex)) {
+                showDomainView(treeModelProxy.getDomain(currentIndex))
+            } else if (treeModelProxy.getIsRowTopic(currentIndex)) {
+                showTopicEndpointView(treeModelProxy.getDomain(currentIndex), treeModelProxy.getName(currentIndex))
             } else {
                 console.log("Nothing found, clear view.")
                 clearView()
             }
         }
     }
-    model: treeModel
+    model: treeModelProxy
 
     delegate: Item {
         implicitWidth: domainSplit.width


### PR DESCRIPTION
This PR:
- Add search to filter topic names
- Little Refactor: Split the TreeModel file into multiple files in a separate folder

Below are screenshots.

1. This screenshot shows the filtered topics (with filtering)
<img width="1377" height="852" alt="Screenshot 2025-07-27 165939" src="https://github.com/user-attachments/assets/036ce746-b0ad-4bd3-8e84-97309c38f913" />

2. This screenshot shows all topics (without filtering)
<img width="1377" height="852" alt="Screenshot 2025-07-27 165959" src="https://github.com/user-attachments/assets/c49bf020-5c6d-4d5f-9c9c-fb4f1f2a35d3" />



@eboasson could you have a look? :)