### PR TITLE
update ci python version to py3.10

### DIFF
--- a/.azure/templates/build-insight.yml
+++ b/.azure/templates/build-insight.yml
@@ -16,7 +16,7 @@ steps:
   - task: UsePythonVersion@0
     displayName: Fetch Python
     inputs:
-      versionSpec: '3.9'
+      versionSpec: '3.10'
       architecture: 'x64'
   - script: python -m pip install --upgrade pip
     displayName: 'Update pip'


### PR DESCRIPTION
This PR updates the python version to 3.10 used by the CI to build Cyclone Insight.
