### PR TITLE
update macos runner to macos-15-intel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,8 +28,8 @@ jobs:
     matrix:
       'Ubuntu_22.04_LTS_x64':
         image: ubuntu-22.04
-      'macOS_13_x64':
-        image: macOS-13
+      'macOS_15_x64':
+        image: macos-15-intel
       'Windows_Server_2022_x64':
         image: windows-2022
   steps:


### PR DESCRIPTION
This PR updates the deprecated macos-13 runner to macos-15-intel (they changed the naming scheme).

I think it makes sense to stay on the x64 machine because the resulting app can be executed on both intel and apple silicon (rosetta) macs.

@eboasson could you have a look? :)