### PR TITLE
feature/shortcuts

### DIFF
--- a/src/views/Overview.qml
+++ b/src/views/Overview.qml
@@ -228,7 +228,6 @@ SplitView {
     function switchToTab(targetIndex) {
         mainLayoutId.currentIndex = targetIndex
         bar.currentIndex = targetIndex
-        //bar.contentItem.children[targetIndex].forceActiveFocus()
     }
 
 }

--- a/src/views/Overview.qml
+++ b/src/views/Overview.qml
@@ -188,4 +188,47 @@ SplitView {
         }
         clearView()
     }
+
+    Shortcut {
+        sequences: [ StandardKey.New ]
+        sequence: "Ctrl+1"
+        onActivated: {
+            console.log("Ctrl+1 pressed!")
+            switchToTab(0)
+        }
+    }
+
+    Shortcut {
+        sequences: [ StandardKey.New ]
+        sequence: "Ctrl+2"
+        onActivated: {
+            console.debug("Ctrl+2 pressed!")
+            switchToTab(1)
+        }
+    }
+
+    Shortcut {
+        sequences: [ StandardKey.New ]
+        sequence: "Ctrl+3"
+        onActivated: {
+            console.debug("Ctrl+3 pressed!")
+            switchToTab(2)
+        }
+    }
+
+    Shortcut {
+        sequences: [ StandardKey.New ]
+        sequence: "Ctrl+4"
+        onActivated: {
+            console.debug("Ctrl+4 pressed!")
+            switchToTab(3)
+        }
+    }
+
+    function switchToTab(targetIndex) {
+        mainLayoutId.currentIndex = targetIndex
+        bar.currentIndex = targetIndex
+        //bar.contentItem.children[targetIndex].forceActiveFocus()
+    }
+
 }

--- a/src/views/main.qml
+++ b/src/views/main.qml
@@ -79,18 +79,19 @@ ApplicationWindow {
 
     Shortcut {
         sequences: [ StandardKey.New ]
-        sequence: "Ctrl+0"
+        sequence: "Ctrl+,"
         onActivated: {
-            console.debug("Ctrl+1 pressed!")
-            layout.currentIndex = 1
+            console.debug("Ctrl+, pressed!")
+            layout.currentIndex = 0
         }
     }
 
     Shortcut {
         sequences: [ StandardKey.New ]
-        sequence: "Ctrl+,"
+        sequence: "Ctrl+0"
         onActivated: {
-            console.debug("Ctrl+, pressed → Open Preferences")
+            console.debug("Ctrl+0 pressed!")
+            layout.currentIndex = 1
         }
     }
 

--- a/src/views/main.qml
+++ b/src/views/main.qml
@@ -77,6 +77,23 @@ ApplicationWindow {
         }
     }
 
+    Shortcut {
+        sequences: [ StandardKey.New ]
+        sequence: "Ctrl+0"
+        onActivated: {
+            console.debug("Ctrl+1 pressed!")
+            layout.currentIndex = 1
+        }
+    }
+
+    Shortcut {
+        sequences: [ StandardKey.New ]
+        sequence: "Ctrl+,"
+        onActivated: {
+            console.debug("Ctrl+, pressed → Open Preferences")
+        }
+    }
+
     AboutWindow {
         id: aboutWindow
     }


### PR DESCRIPTION
This PR implements keyboard shortcuts for faster navigation.
On Linux/Windows via CTRL button and on MacOS via Command Button.

Navigate Views:
- `CTRL + 0`: Open Home View
- `CTRL + ,`: Open Settings View

Navigate Tabs:
- `CTRL + 1`: Open Details Tab
- `CTRL + 2`: Open Statistics Tab
- `CTRL + 3`: Open Tester Tab
- `CTRL + 4`: Open Listener Tab

@eboasson could you have a look? :)