### PR TITLE
feature/additional-default-domains

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -39,7 +39,7 @@ else:
 import argparse
 from PySide6.QtWidgets import QApplication
 from PySide6.QtQml import QQmlApplicationEngine, qmlRegisterType
-from PySide6.QtCore import qInstallMessageHandler, QUrl, QThread, qVersion, Qt
+from PySide6.QtCore import qInstallMessageHandler, QUrl, QThread, qVersion, Qt, QSettings
 from PySide6.QtGui import QIcon, QPixmap
 from PySide6.QtQuickControls2 import QQuickStyle
 from loguru import logger as logging
@@ -190,14 +190,28 @@ if __name__ == "__main__":
         logging.critical("Failed to load qml")
         sys.exit(-1)
 
-    # Add all configured domains
-    domainIds = getConfiguredDomainIds()    
-    for domainId in domainIds:
-        data.add_domain(domainId)
+    domainIds: list[int] = []
+
+    # Domains configured in cyclone-insight settings
+    rawDomainsStr = QSettings().value("general/domains", "", type=str)
+    for domainIdStr in rawDomainsStr.split(","):
+        try:
+            domainIds.append(int(domainIdStr.strip()))
+        except Exception:
+            pass
+
+    # Add all configured domains from cyclone xml config
+    domainIds.extend(getConfiguredDomainIds())
 
     # fallback
     if len(domainIds) == 0:
-        data.add_domain(0)
+        domainIds.append(0)
+
+    domainIds.sort()
+
+    # Add domains
+    for domainId in domainIds:
+        data.add_domain(domainId)
 
     logging.info("qt ...")
     ret_code = app.exec()

--- a/src/translations/cyclonedds-insight_de.ts
+++ b/src/translations/cyclonedds-insight_de.ts
@@ -136,6 +136,13 @@
         <translation>HTTP-Proxy verwenden</translation>
     </message>
 
+    <message id="settings.default_domains.label">
+        <translation>Standard-Domains</translation>
+    </message>
+    <message id="settings.default_domains.description">
+        <translation>Komma-separierte Liste von Domains welche beim Start beigetreten werden.</translation>
+    </message>
+
     <message id="infinite">
         <translation>Unbegrenzt</translation>
     </message>

--- a/src/translations/cyclonedds-insight_en.ts
+++ b/src/translations/cyclonedds-insight_en.ts
@@ -131,6 +131,13 @@
         <translation>Use HTTP Proxy</translation>
     </message>
 
+    <message id="settings.default_domains.label">
+        <translation>Default-Domains</translation>
+    </message>
+    <message id="settings.default_domains.description">
+        <translation>Comma-separated list of domains to join at startup.</translation>
+    </message>
+
     <message id="infinite">
         <translation>Infinite</translation>
     </message>

--- a/src/views/SettingsView.qml
+++ b/src/views/SettingsView.qml
@@ -32,6 +32,11 @@ Rectangle {
         property alias port: settingsViewId.port
     }
 
+    Settings {
+        category: "general"
+        property alias domains: defaultDomainsTextField.text
+    }
+
     ScrollView {
         anchors.fill: parent
 
@@ -186,6 +191,35 @@ Rectangle {
             Item {
                 Layout.columnSpan: 2
                 Layout.fillHeight: true
+            }
+
+            Label {
+                text: qsTrId("settings.default_domains.label") + ":"
+            }
+            TextField {
+                id: defaultDomainsTextField
+                text: ""
+                Layout.preferredWidth: 380
+                Layout.minimumWidth: 50
+                readOnly: false
+                validator: RegularExpressionValidator {
+                    regularExpression: /^((0|[1-9]\d?|1\d\d|2[0-1]\d|22\d|23[0-2])(,(0|[1-9]\d?|1\d\d|2[0-1]\d|22\d|23[0-2]))*)?$/
+                }
+                onTextChanged: {
+                    const parts = text.split(",")
+                    const seen = new Set()
+                    for (let i = 0; i < parts.length; ++i) {
+                        if (parts[i] !== "" && seen.has(parts[i])) {
+                            text = parts.slice(0, i).concat(parts.slice(i + 1)).join(",")
+                            return
+                        }
+                        seen.add(parts[i])
+                    }
+                }
+            }
+            Item {}
+            Label {
+                text: qsTrId("settings.default_domains.description")
             }
         }
     }


### PR DESCRIPTION
This PR adds a default domains setting that allows joining specific DDS domains at startup, in addition to any domains configured via the Cyclone DDS XML configuration (CYCLONEDDS_URI).

This addresses a common lab setup where the XML configuration uses `any`, while multiple DDS domains may be active on the same network. In this particular environment, the application should consistently join the same three specific domains rather than relying solely on the broader XML configuration.

Screenshot:
<img width="1212" height="790" alt="Screenshot 2026-05-10 at 18 16 55" src="https://github.com/user-attachments/assets/d25614c8-6bb2-4d51-92fb-0a82c1af5053" />

@eboasson could you have a look?