### PR TITLE
feature/tester-duplicate-preset

### DIFF
--- a/src/models/tester_model.py
+++ b/src/models/tester_model.py
@@ -573,3 +573,31 @@ class TesterModel(QAbstractListModel):
         TesterModel.untitiledSequenceCount += 1
         self.endResetModel()
         self.countChanged.emit()
+
+    @Slot(int)
+    def duplicatePreset(self, currentIndex: int):
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return
+        logging.info(f"Duplicate preset at index {currentIndex}")
+        mId = list(self.items.keys())[int(currentIndex)]
+        item = self.items[mId]
+        if isinstance(item, WriterItem):
+            newId = str(uuid.uuid4())
+            newPresetName = f"{item.getPresetName()}-copy"
+            rootNode = self.dataModelHandler.getRootNode(item.getTopicType())
+            dataTreeModel = DataTreeModel(rootNode, parent=self)
+            dataTreeModel.fromJson(item.getDataTreeModel().toJson()["root"], self.dataModelHandler)
+            self.beginResetModel()
+            self.items[newId] = WriterItem(item.getDomainId(), item.getTopicName(), item.getTopicType(), item.getQmlCode(), None, dataTreeModel, newPresetName, copy.deepcopy(item.qos))
+            self.endResetModel()
+            self.countChanged.emit()
+        elif isinstance(item, SequenceItem):
+            newId = str(uuid.uuid4())
+            newPresetName = f"{item.getPresetName()}-copy"
+            self.beginResetModel()
+            newSequenceItem = SequenceItem(newPresetName)
+            for itemSeqId in item.sequenceItems:
+                newSequenceItem.addSequenceItem(itemSeqId)
+            self.items[newId] = newSequenceItem
+            self.endResetModel()
+            self.countChanged.emit()

--- a/src/translations/cyclonedds-insight_de.ts
+++ b/src/translations/cyclonedds-insight_de.ts
@@ -229,5 +229,12 @@
         <translation>Dokumentation</translation>
     </message>
 
+    <message id="tester.duplicate">
+        <translation>Duplizieren</translation>
+    </message>
+    <message id="tester.create-sequence">
+        <translation>Sequence erstellen</translation>
+    </message>
+
 </context>
 </TS>

--- a/src/translations/cyclonedds-insight_en.ts
+++ b/src/translations/cyclonedds-insight_en.ts
@@ -223,5 +223,12 @@
         <translation>Browse Options</translation>
     </message>
 
+    <message id="tester.duplicate">
+        <translation>Duplicate</translation>
+    </message>
+    <message id="tester.create-sequence">
+        <translation>Create Sequence</translation>
+    </message>
+
 </context>
 </TS>

--- a/src/views/ListenerView.qml
+++ b/src/views/ListenerView.qml
@@ -116,10 +116,6 @@ Rectangle {
                     }
                 }
             }
-            Button {
-                text: "Delete All Readers"
-                onClicked: listenerModel.deleteAllReaders()
-            }
             Item {
                 implicitHeight: 1
                 implicitWidth: 1
@@ -271,16 +267,31 @@ Rectangle {
             color: rootWindow.isDarkMode ? Constants.darkMainContent : Constants.lightMainContent
         }
 
+        onClosed: {
+            searchField.clear()
+            listenerProxyModel.searchText = ""
+        }
+
         ColumnLayout {
             anchors.fill: parent
             anchors.margins: 8
             spacing: 8
 
-            TextField {
-                id: searchField
+            RowLayout {
                 Layout.fillWidth: true
-                placeholderText: qsTrId("general.search.placeholder")
-                onAccepted: listenerProxyModel.searchText = text
+                spacing: 8
+
+                TextField {
+                    id: searchField
+                    Layout.fillWidth: true
+                    placeholderText: qsTrId("general.search.placeholder")
+                    onAccepted: listenerProxyModel.searchText = text
+                }
+
+                Button {
+                    text: "Delete All"
+                    onClicked: listenerModel.deleteAllReaders()
+                }
             }
 
             ListView {

--- a/src/views/TesterView.qml
+++ b/src/views/TesterView.qml
@@ -58,6 +58,7 @@ Rectangle {
 
             Button {
                 text:  qsTrId("tester.duplicate")
+                enabled: librariesCombobox.count > 0
                 onClicked: {
                     testerModel.duplicatePreset(librariesCombobox.currentIndex)
                     librariesCombobox.currentIndex = librariesCombobox.count - 1
@@ -114,8 +115,13 @@ Rectangle {
                     MenuItem {
                         text: "Delete Current"
                         onClicked: {
-                            testerModel.deleteWriter(librariesCombobox.currentIndex)
-                            librariesCombobox.currentIndex = librariesCombobox.currentIndex - 1
+                            const idx = librariesCombobox.currentIndex
+                            testerModel.deleteWriter(idx)
+                            if (librariesCombobox.count > 0) {
+                                librariesCombobox.currentIndex = Math.max(0, idx - 1)
+                            } else {
+                                librariesCombobox.currentIndex = -1
+                            }
                         }
                     }
                     MenuItem {
@@ -144,15 +150,20 @@ Rectangle {
 
             ComboBox {
                 id: librariesCombobox
+                readonly property bool isMac: Qt.platform.os === "osx"
+                readonly property int popupOverlap: isMac ? 8 : 0
+                readonly property int popupInset: isMac ? 8 : 0
                 model: testerModel
                 Layout.fillWidth: true
                 textRole: "name"
+                enabled: librariesCombobox.count > 0
 
                 property string searchText: ""
 
                 popup: Popup {
-                    y: librariesCombobox.height
-                    width: librariesCombobox.width
+                    y: librariesCombobox.height  - librariesCombobox.popupOverlap
+                    x: librariesCombobox.popupInset
+                    width: librariesCombobox.width - (2 * librariesCombobox.popupInset)
                     height: listenerTabId.height * 0.6
                     padding: 4
                     clip: true
@@ -161,10 +172,10 @@ Rectangle {
                         TextField {
                             id: searchField
                             Layout.fillWidth: true
-                            placeholderText: qsTr("Search...")
+                            placeholderText: qsTrId("general.search.placeholder")
                             text: librariesCombobox.searchText
 
-                            onTextChanged: librariesCombobox.searchText = text
+                            onAccepted: librariesCombobox.searchText = text
 
                             Keys.onEscapePressed: librariesCombobox.popup.close()
                         }
@@ -201,7 +212,9 @@ Rectangle {
                         searchField.selectAll()
                     }
 
-                    onClosed: librariesCombobox.searchText = ""
+                    onClosed: {
+                        librariesCombobox.searchText = ""
+                    }
                 }
 
                 onCurrentIndexChanged: {
@@ -421,7 +434,7 @@ Rectangle {
                 id: treeView
                 model: dataTreeModel
                 anchors.fill: parent
-                visible: dataTreeModel !== null && sequenceModel === null
+                visible: dataTreeModel !== null && sequenceModel === null && librariesCombobox.count > 0
                 clip: true
                 ScrollBar.vertical: ScrollBar {}
                 selectionModel: ItemSelectionModel {

--- a/src/views/TesterView.qml
+++ b/src/views/TesterView.qml
@@ -147,16 +147,73 @@ Rectangle {
                 model: testerModel
                 Layout.fillWidth: true
                 textRole: "name"
+
+                property string searchText: ""
+
+                popup: Popup {
+                    y: librariesCombobox.height
+                    width: librariesCombobox.width
+                    height: listenerTabId.height * 0.6
+                    padding: 4
+                    clip: true
+
+                    contentItem: ColumnLayout {
+                        TextField {
+                            id: searchField
+                            Layout.fillWidth: true
+                            placeholderText: qsTr("Search...")
+                            text: librariesCombobox.searchText
+
+                            onTextChanged: librariesCombobox.searchText = text
+
+                            Keys.onEscapePressed: librariesCombobox.popup.close()
+                        }
+                        ListView {
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            clip: true
+                            model: testerModel
+                            ScrollBar.vertical: ScrollBar {
+                                policy: ScrollBar.AsNeeded
+                            }
+
+                            delegate: ItemDelegate {
+                                width: ListView.view.width
+                                text: model.name
+                                visible: text.toLowerCase().includes(
+                                    librariesCombobox.searchText.toLowerCase()
+                                )
+                                height: visible ? implicitHeight : 0
+
+                                onClicked: {
+                                    librariesCombobox.currentIndex = index
+                                    librariesCombobox.popup.close()
+
+                                    dataTreeModel = testerModel.getTreeModel(index)
+                                    sequenceModel = testerModel.getSequenceModel(index)
+                                }
+                            }
+                        }
+                    }
+
+                    onOpened: {
+                        searchField.forceActiveFocus()
+                        searchField.selectAll()
+                    }
+
+                    onClosed: librariesCombobox.searchText = ""
+                }
+
                 onCurrentIndexChanged: {
-                    if (testerModel) {
+                    if (testerModel && currentIndex >= 0) {
                         dataTreeModel = testerModel.getTreeModel(currentIndex)
                         sequenceModel = testerModel.getSequenceModel(currentIndex)
                     }
                 }
+
                 onCountChanged: {
-                    if (librariesCombobox.count > 0 && librariesCombobox.currentIndex === -1) {
-                        librariesCombobox.currentIndex = 0;
-                    }
+                    if (count > 0 && currentIndex === -1)
+                        currentIndex = 0
                 }
             }
 

--- a/src/views/TesterView.qml
+++ b/src/views/TesterView.qml
@@ -57,7 +57,15 @@ Rectangle {
             }
 
             Button {
-                text: "Create Sequence"
+                text:  qsTrId("tester.duplicate")
+                onClicked: {
+                    testerModel.duplicatePreset(librariesCombobox.currentIndex)
+                    librariesCombobox.currentIndex = librariesCombobox.count - 1
+                }
+            }
+
+            Button {
+                text: qsTrId("tester.create-sequence")
                 onClicked: {
                     testerModel.addSequence()
                     librariesCombobox.currentIndex = librariesCombobox.count - 1


### PR DESCRIPTION
This PR closes #108 and implements:
- duplicate tester preset
- add search-bar in tester preset selection
- fix selection after deletion of first tester preset
- integrate delete-all-listener button in manage-readers

@eboasson could you have a look?