### PR TITLE
feature/multiple-data-in-preset-and-description

### DIFF
--- a/resources.qrc
+++ b/resources.qrc
@@ -43,6 +43,9 @@
         <file>src/views/selection_details/TopicEndpointView.qml</file>
         <file>src/views/icons/WarningTriangle.qml</file>
         <file>src/views/icons/ChevronIcon.qml</file>
+        <file>src/views/icons/SearchIcon.qml</file>
+        <file>src/views/icons/MenuIcon.qml</file>
+        <file>src/views/icons/ArrowIcon.qml</file>
         <file>src/views/IdlDropArea.qml</file>
         <file>src/views/Overview.qml</file>
         <file>src/views/DataModelOverview.qml</file>

--- a/resources.qrc
+++ b/resources.qrc
@@ -42,6 +42,7 @@
         <file>src/views/TopicOverview.qml</file>
         <file>src/views/selection_details/TopicEndpointView.qml</file>
         <file>src/views/icons/WarningTriangle.qml</file>
+        <file>src/views/icons/ChevronIcon.qml</file>
         <file>src/views/IdlDropArea.qml</file>
         <file>src/views/Overview.qml</file>
         <file>src/views/DataModelOverview.qml</file>

--- a/src/models/tester_model.py
+++ b/src/models/tester_model.py
@@ -36,6 +36,7 @@ import json
 class SequenceItem(QAbstractListModel):
 
     NameRole = Qt.UserRole + 1
+    DataItemIdRole = Qt.UserRole + 2
 
     def __init__(self, presetName, description="", parent=QObject()):
         super().__init__(parent)
@@ -49,14 +50,18 @@ class SequenceItem(QAbstractListModel):
             return None
         row = index.row()
 
+        dataItemId = self.sequenceItems[row]
         if role == self.NameRole or role == Qt.DisplayRole:
-            return f"{self.sequenceItems[row]}"
+            return dataItemId
+        if role == self.DataItemIdRole:
+            return dataItemId
         
         return None
 
     def roleNames(self) -> dict[int, QByteArray]:
         return {
-            self.NameRole: b'name'
+            self.NameRole: b'name',
+            self.DataItemIdRole: b'dataItemId'
         }
 
     def rowCount(self, index: QModelIndex = QModelIndex()) -> int:
@@ -78,9 +83,9 @@ class SequenceItem(QAbstractListModel):
         return self.dataTreeModel.rootNode.role == DataTreeModel.IsSequenceRole
 
     @Slot(str)
-    def addSequenceItem(self, itemId):
+    def addSequenceItem(self, dataItemId):
         self.beginResetModel()
-        self.sequenceItems.append(itemId)
+        self.sequenceItems.append(dataItemId)
         self.endResetModel()
 
     @Slot(int)
@@ -92,13 +97,32 @@ class SequenceItem(QAbstractListModel):
         self.endResetModel()
 
 class WriterItem:
-    def __init__(self, domainId, topic_name, topic_type, qmlCode, pyCode, dataTreeModel, presetName, qos={}, description=""):
+    def __init__(self, writerId, domainId, topic_name, topic_type, qmlCode, pyCode, dataTreeModels, presetName, qos={}, description="", dataItemNames=None, dataItemIds=None):
+        self.writerId = writerId
         self.domainId = domainId
         self.topic_name = topic_name
         self.topic_type = topic_type
         self.qmlCode = qmlCode
         self.pyCode = pyCode
-        self.dataTreeModel = dataTreeModel
+        self.dataTreeModels = dataTreeModels
+        self.dataItemNames = [
+            str(name).strip() or f"Data {index + 1}"
+            for index, name in enumerate(dataItemNames)
+        ] if isinstance(dataItemNames, list) else []
+        while len(self.dataItemNames) < len(self.dataTreeModels):
+            self.dataItemNames.append(f"Data {len(self.dataItemNames) + 1}")
+        self.dataItemNames = self.dataItemNames[:len(self.dataTreeModels)]
+        importedDataItemIds = list(dataItemIds) if isinstance(dataItemIds, list) else []
+        self.dataItemIds = []
+        for dataIndex in range(len(self.dataTreeModels)):
+            dataItemId = writerId if dataIndex == 0 else (
+                importedDataItemIds[dataIndex]
+                if dataIndex < len(importedDataItemIds)
+                else ""
+            )
+            if not dataItemId or dataItemId in self.dataItemIds:
+                dataItemId = str(uuid.uuid4())
+            self.dataItemIds.append(dataItemId)
         self.presetName = presetName
         self.description = description
         self.qos = qos
@@ -125,8 +149,61 @@ class WriterItem:
     def getDomainId(self):
         return self.domainId
 
-    def getDataTreeModel(self):
-        return self.dataTreeModel
+    def getDataTreeModel(self, dataIndex=0):
+        if dataIndex < 0 or dataIndex >= len(self.dataTreeModels):
+            return None
+        return self.dataTreeModels[dataIndex]
+
+    def getDataTreeModels(self):
+        return self.dataTreeModels
+
+    def addDataTreeModel(self, dataTreeModel, name=None, dataItemId=None):
+        self.dataTreeModels.append(dataTreeModel)
+        self.dataItemNames.append(name or f"Data {len(self.dataTreeModels)}")
+        self.dataItemIds.append(dataItemId or str(uuid.uuid4()))
+
+    def removeDataTreeModel(self, dataIndex):
+        if len(self.dataTreeModels) <= 1 or dataIndex < 0 or dataIndex >= len(self.dataTreeModels):
+            return "", ""
+        dataTreeModel = self.dataTreeModels.pop(dataIndex)
+        del self.dataItemNames[dataIndex]
+        removedDataItemId = self.dataItemIds.pop(dataIndex)
+        promotedDataItemId = ""
+        if dataIndex == 0:
+            promotedDataItemId = self.dataItemIds[0]
+            self.dataItemIds[0] = self.writerId
+        dataTreeModel.deleteLater()
+        return removedDataItemId, promotedDataItemId
+
+    def getDataTreeModelCount(self):
+        return len(self.dataTreeModels)
+
+    def getDataItemName(self, dataIndex):
+        if dataIndex < 0 or dataIndex >= len(self.dataItemNames):
+            return ""
+        return self.dataItemNames[dataIndex]
+
+    def setDataItemName(self, dataIndex, name):
+        if dataIndex < 0 or dataIndex >= len(self.dataItemNames):
+            return
+        self.dataItemNames[dataIndex] = name
+
+    def getDataItemNames(self):
+        return self.dataItemNames
+
+    def getDataItemId(self, dataIndex):
+        if dataIndex < 0 or dataIndex >= len(self.dataItemIds):
+            return ""
+        return self.dataItemIds[dataIndex]
+
+    def getDataItemIds(self):
+        return self.dataItemIds
+
+    def getDataIndexById(self, dataItemId):
+        try:
+            return self.dataItemIds.index(dataItemId)
+        except ValueError:
+            return -1
     
     def getQmlCode(self):
         return self.qmlCode
@@ -180,6 +257,34 @@ class TesterModel(QAbstractListModel):
     def resetExportData(self):
         self.exportData = { "presets": [], "sequence_presets": [] }
 
+    def _createDataTreeModel(self, topicType, messageRoot=None):
+        rootNode = self.dataModelHandler.getRootNode(topicType)
+        dataTreeModel = DataTreeModel(rootNode, parent=self)
+        if messageRoot:
+            dataTreeModel.fromJson(messageRoot, self.dataModelHandler)
+        return dataTreeModel
+
+    def _getDataReference(self, dataItemId):
+        for writerId, item in self.items.items():
+            if isinstance(item, WriterItem):
+                dataIndex = item.getDataIndexById(dataItemId)
+                if dataIndex >= 0:
+                    return writerId, dataIndex
+        return "", -1
+
+    def _getImportedSequenceDataItemId(self, sequenceItem):
+        if isinstance(sequenceItem, str):
+            return sequenceItem
+        return ""
+
+    def _getAvailableDataReferences(self):
+        references = []
+        for writerId, item in self.items.items():
+            if isinstance(item, WriterItem):
+                for dataIndex in range(item.getDataTreeModelCount()):
+                    references.append(item.getDataItemId(dataIndex))
+        return references
+
     def data(self, index: QModelIndex, role: int = Qt.DisplayRole):
         if not index.isValid():
             return None
@@ -222,20 +327,121 @@ class TesterModel(QAbstractListModel):
     def rowCount(self, index: QModelIndex = QModelIndex()) -> int:
         return len(self.items.keys())
 
-    @Slot(int, result=DataTreeModel)
-    def getTreeModel(self, currentIndex: int) -> DataTreeModel:
-        if currentIndex < 0:
-            return
+    @Slot(int, int, result=DataTreeModel)
+    def getTreeModel(self, currentIndex: int, dataIndex: int = 0) -> DataTreeModel:
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return None
         mId = list(self.items.keys())[int(currentIndex)]
         item = self.items[mId]
         if isinstance(item, WriterItem):
-            return item.getDataTreeModel()
+            return item.getDataTreeModel(dataIndex)
         return None
+
+    @Slot(int, result=int)
+    def getDataItemCount(self, currentIndex: int) -> int:
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return 0
+        mId = list(self.items.keys())[int(currentIndex)]
+        item = self.items[mId]
+        if isinstance(item, WriterItem):
+            return item.getDataTreeModelCount()
+        return 0
+
+    @Slot(result=int)
+    def getAvailableDataItemCount(self) -> int:
+        return len(self._getAvailableDataReferences())
+
+    @Slot(int, result=str)
+    def getAvailableDataItemName(self, availableIndex: int) -> str:
+        references = self._getAvailableDataReferences()
+        if availableIndex < 0 or availableIndex >= len(references):
+            return ""
+        return self.getDataItemDisplayName(references[availableIndex])
+
+    @Slot(int, result=str)
+    def getAvailableDataItemId(self, availableIndex: int) -> str:
+        references = self._getAvailableDataReferences()
+        if availableIndex < 0 or availableIndex >= len(references):
+            return ""
+        return references[availableIndex]
+
+    @Slot(str, result=str)
+    def getDataItemDisplayName(self, dataItemId: str) -> str:
+        writerId, dataIndex = self._getDataReference(dataItemId)
+        item = self.items.get(writerId)
+        if not isinstance(item, WriterItem):
+            return "Unknown"
+        return f"{item.getPresetName()} - {item.getDataItemName(dataIndex)}"
+
+    @Slot(int, int, result=str)
+    def getDataItemName(self, currentIndex: int, dataIndex: int) -> str:
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return ""
+        mId = list(self.items.keys())[int(currentIndex)]
+        item = self.items[mId]
+        if isinstance(item, WriterItem):
+            return item.getDataItemName(dataIndex)
+        return ""
+
+    @Slot(int, int, str)
+    def setDataItemName(self, currentIndex: int, dataIndex: int, name: str):
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return
+        mId = list(self.items.keys())[int(currentIndex)]
+        item = self.items[mId]
+        if not isinstance(item, WriterItem):
+            return
+        item.setDataItemName(dataIndex, name.strip() or f"Data {dataIndex + 1}")
+        idx = self.index(currentIndex, 0)
+        self.dataChanged.emit(idx, idx, [self.DataModelRole])
+
+    @Slot(int, result=int)
+    def addDataItem(self, currentIndex: int) -> int:
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return -1
+        mId = list(self.items.keys())[int(currentIndex)]
+        item = self.items[mId]
+        if not isinstance(item, WriterItem):
+            return -1
+
+        item.addDataTreeModel(self._createDataTreeModel(item.getTopicType()))
+        idx = self.index(currentIndex, 0)
+        self.dataChanged.emit(idx, idx, [self.DataModelRole])
+        return item.getDataTreeModelCount() - 1
+
+    @Slot(int, int, result=int)
+    def removeDataItem(self, currentIndex: int, dataIndex: int) -> int:
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return -1
+        mId = list(self.items.keys())[int(currentIndex)]
+        item = self.items[mId]
+        if not isinstance(item, WriterItem):
+            return dataIndex
+        removedDataItemId, promotedDataItemId = item.removeDataTreeModel(dataIndex)
+        if not removedDataItemId:
+            return dataIndex
+
+        for sequenceItem in self.items.values():
+            if not isinstance(sequenceItem, SequenceItem):
+                continue
+            updatedReferences = [
+                item.writerId if reference == promotedDataItemId else reference
+                for reference in sequenceItem.sequenceItems
+                if reference != removedDataItemId
+            ]
+            if updatedReferences != sequenceItem.sequenceItems:
+                sequenceItem.beginResetModel()
+                sequenceItem.sequenceItems = updatedReferences
+                sequenceItem.endResetModel()
+
+        idx = self.index(currentIndex, 0)
+        self.dataChanged.emit(idx, idx, [self.DataModelRole])
+        return min(dataIndex, item.getDataTreeModelCount() - 1)
 
     @Slot(int, result=SequenceItem)
     def getSequenceModel(self, currentIndex: int) -> SequenceItem:
-        if currentIndex < 0:
-            return
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return None
         mId = list(self.items.keys())[int(currentIndex)]
         item = self.items[mId]
         if isinstance(item, SequenceItem):
@@ -264,9 +470,10 @@ class TesterModel(QAbstractListModel):
         if isinstance(item, SequenceItem):
             if len(item.sequenceItems) == 0:
                 return False
-            for itemCurrentId in item.sequenceItems:
-                if itemCurrentId not in self.items.keys():
-                    logging.warning(f"Item id {itemCurrentId} not found in items")
+            for dataItemId in item.sequenceItems:
+                itemCurrentId, _ = self._getDataReference(dataItemId)
+                if itemCurrentId not in self.items:
+                    logging.warning(f"Data item id {dataItemId} not found in items")
                     continue
                 itemCurr = self.items[itemCurrentId]
                 if isinstance(itemCurr, WriterItem):
@@ -288,9 +495,14 @@ class TesterModel(QAbstractListModel):
                 self.threads[key].deleteWriter(mId)
             item.setIsStarted(False)
         if isinstance(item, SequenceItem):
-            for itemCurrentId in item.sequenceItems:
-                if itemCurrentId not in self.items.keys():
-                    logging.warning(f"Item id {itemCurrentId} not found in items")
+            stoppedWriterIds = set()
+            for dataItemId in item.sequenceItems:
+                itemCurrentId, _ = self._getDataReference(dataItemId)
+                if itemCurrentId in stoppedWriterIds:
+                    continue
+                stoppedWriterIds.add(itemCurrentId)
+                if itemCurrentId not in self.items:
+                    logging.warning(f"Data item id {dataItemId} not found in items")
                     continue
                 itemCurr = self.items[itemCurrentId]
                 if isinstance(itemCurr, WriterItem):
@@ -309,25 +521,18 @@ class TesterModel(QAbstractListModel):
         if isinstance(item, WriterItem):
             self.createEndpointFromTesterSignal.emit(mId, item.getDomainId(), item.getTopicName(), item.getTopicType(), 4, item.getPresetName(), {}, copy.deepcopy(item.qos))
         if isinstance(item, SequenceItem):
-            for itemCurrentId in item.sequenceItems:
-                if itemCurrentId not in self.items.keys():
-                    logging.warning(f"Item id {itemCurrentId} not found in items")
+            startedWriterIds = set()
+            for dataItemId in item.sequenceItems:
+                itemCurrentId, _ = self._getDataReference(dataItemId)
+                if itemCurrentId in startedWriterIds:
+                    continue
+                startedWriterIds.add(itemCurrentId)
+                if itemCurrentId not in self.items:
+                    logging.warning(f"Data item id {dataItemId} not found in items")
                     continue
                 itemCurr = self.items[itemCurrentId]
                 if isinstance(itemCurr, WriterItem):
                     self.createEndpointFromTesterSignal.emit(itemCurrentId, itemCurr.getDomainId(), itemCurr.getTopicName(), itemCurr.getTopicType(), 4, itemCurr.getPresetName(), {}, copy.deepcopy(itemCurr.qos))
-
-    @Slot(int, result=str)
-    def getItemId(self, currentIndex: int) -> str:
-        if currentIndex < 0:
-            return
-        return list(self.items.keys())[int(currentIndex)]
-
-    @Slot(str, result=str)
-    def getNameById(self, itemId: str) -> str:
-        if itemId in self.items.keys():
-            return self.items[itemId].getPresetName()
-        return None
 
     @Slot(int, result=str)
     def getPresetName(self, currentIndex: int) -> str:
@@ -380,20 +585,21 @@ class TesterModel(QAbstractListModel):
             self.dataChanged.emit(idx, idx, [self.IsStarted, self.NameRole, self.PresetNameRole])
         else:
             self.beginResetModel()
-            rootNode = self.dataModelHandler.getRootNode(topic_type)
-            dataTreeModel = DataTreeModel(rootNode, parent=self)
-            self.items[id] = WriterItem(domainId, topic_name, topic_type, "", None, dataTreeModel, f"Untitled-{TesterModel.untitiledCount}", qos)
+            dataTreeModel = self._createDataTreeModel(topic_type)
+            self.items[id] = WriterItem(id, domainId, topic_name, topic_type, "", None, [dataTreeModel], f"Untitled-{TesterModel.untitiledCount}", qos)
             TesterModel.untitiledCount += 1
             self.items[id].setIsStarted(True)
             self.endResetModel()
             self.countChanged.emit()
 
-    @Slot(int, QModelIndex)
-    def addArrayItem(self, currentIndex: int, currentTreeIndex: QModelIndex):
+    @Slot(int, int, QModelIndex)
+    def addArrayItem(self, currentIndex: int, dataIndex: int, currentTreeIndex: QModelIndex):
         logging.debug("Add Array Item")
         mId = list(self.items.keys())[int(currentIndex)]
         item = self.items[mId]
-        dataTreeModel = item.getDataTreeModel()
+        dataTreeModel = item.getDataTreeModel(dataIndex)
+        if dataTreeModel is None:
+            return
         if currentTreeIndex.isValid():
             item: DataTreeNode = currentTreeIndex.internalPointer()
             if item.itemArrayTypeName:
@@ -411,13 +617,15 @@ class TesterModel(QAbstractListModel):
         else:
             logging.warning("currentTreeIndex not valid")
 
-    @Slot(int, QModelIndex)
-    def removeArrayItem(self, currentIndex: int, currentTreeIndex: QModelIndex):
+    @Slot(int, int, QModelIndex)
+    def removeArrayItem(self, currentIndex: int, dataIndex: int, currentTreeIndex: QModelIndex):
         logging.debug("Remove Array Item")
         mId = list(self.items.keys())[int(currentIndex)]
         item = self.items[mId]
         if isinstance(item, WriterItem):
-            dataTreeModel = item.getDataTreeModel()
+            dataTreeModel = item.getDataTreeModel(dataIndex)
+            if dataTreeModel is None:
+                return
             if currentTreeIndex.isValid():
                 dataTreeModel.removeArrayItem(currentTreeIndex)
 
@@ -431,59 +639,68 @@ class TesterModel(QAbstractListModel):
         if isinstance(item, WriterItem):
             self.showQml.emit(mId, item.getQmlCode())
 
-    @Slot(int)
-    def writeData(self, currentIndex: int):
+    @Slot(int, int)
+    def writeData(self, currentIndex: int, dataIndex: int):
         logging.trace(f"Write Data pressed on index: {str(currentIndex)}")
         mId = list(self.items.keys())[int(currentIndex)]
         item = self.items[mId]
         if isinstance(item, WriterItem):
-            dataTreeModel = item.getDataTreeModel()
-            self.writeDataSignal.emit(mId, dataTreeModel.getDataObj())
+            dataTreeModel = item.getDataTreeModel(dataIndex)
+            if dataTreeModel is not None:
+                self.writeDataSignal.emit(mId, dataTreeModel.getDataObj())
         elif isinstance(item, SequenceItem):
-            for itemCurrentId in item.sequenceItems:
-                if itemCurrentId not in self.items.keys():
-                    logging.warning(f"Item id {itemCurrentId} not found in items")
+            for dataItemId in item.sequenceItems:
+                itemCurrentId, sequenceDataIndex = self._getDataReference(dataItemId)
+                if itemCurrentId not in self.items:
+                    logging.warning(f"Data item id {dataItemId} not found in items")
                     continue
                 item = self.items[itemCurrentId]
                 if isinstance(item, WriterItem):
-                    dataTreeModel = item.getDataTreeModel()
-                    self.writeDataSignal.emit(itemCurrentId, dataTreeModel.getDataObj())
+                    dataTreeModel = item.getDataTreeModel(sequenceDataIndex)
+                    if dataTreeModel is not None:
+                        self.writeDataSignal.emit(itemCurrentId, dataTreeModel.getDataObj())
 
-    @Slot(int)
-    def disposeData(self, currentIndex: int):
+    @Slot(int, int)
+    def disposeData(self, currentIndex: int, dataIndex: int):
         logging.trace(f"Dispose Data pressed on index: {str(currentIndex)}")
         mId = list(self.items.keys())[int(currentIndex)]
         item = self.items[mId]
         if isinstance(item, WriterItem):
-            dataTreeModel = item.getDataTreeModel()
-            self.disposeDataSignal.emit(mId, dataTreeModel.getDataObj())
+            dataTreeModel = item.getDataTreeModel(dataIndex)
+            if dataTreeModel is not None:
+                self.disposeDataSignal.emit(mId, dataTreeModel.getDataObj())
         elif isinstance(item, SequenceItem):
-            for itemCurrentId in item.sequenceItems:
-                if itemCurrentId not in self.items.keys():
-                    logging.warning(f"Item id {itemCurrentId} not found in items")
+            for dataItemId in item.sequenceItems:
+                itemCurrentId, sequenceDataIndex = self._getDataReference(dataItemId)
+                if itemCurrentId not in self.items:
+                    logging.warning(f"Data item id {dataItemId} not found in items")
                     continue
                 item = self.items[itemCurrentId]
                 if isinstance(item, WriterItem):
-                    dataTreeModel = item.getDataTreeModel()
-                    self.disposeDataSignal.emit(itemCurrentId, dataTreeModel.getDataObj())
+                    dataTreeModel = item.getDataTreeModel(sequenceDataIndex)
+                    if dataTreeModel is not None:
+                        self.disposeDataSignal.emit(itemCurrentId, dataTreeModel.getDataObj())
 
-    @Slot(int)
-    def unregisterData(self, currentIndex: int):
+    @Slot(int, int)
+    def unregisterData(self, currentIndex: int, dataIndex: int):
         logging.trace(f"Unregister Data pressed on index: {str(currentIndex)}")
         mId = list(self.items.keys())[int(currentIndex)]
         item = self.items[mId]
         if isinstance(item, WriterItem):
-            dataTreeModel = item.getDataTreeModel()
-            self.unregisterDataSignal.emit(mId, dataTreeModel.getDataObj())
+            dataTreeModel = item.getDataTreeModel(dataIndex)
+            if dataTreeModel is not None:
+                self.unregisterDataSignal.emit(mId, dataTreeModel.getDataObj())
         elif isinstance(item, SequenceItem):
-            for itemCurrentId in item.sequenceItems:
-                if itemCurrentId not in self.items.keys():
-                    logging.warning(f"Item id {itemCurrentId} not found in items")
+            for dataItemId in item.sequenceItems:
+                itemCurrentId, sequenceDataIndex = self._getDataReference(dataItemId)
+                if itemCurrentId not in self.items:
+                    logging.warning(f"Data item id {dataItemId} not found in items")
                     continue
                 item = self.items[itemCurrentId]
                 if isinstance(item, WriterItem):
-                    dataTreeModel = item.getDataTreeModel()
-                    self.unregisterDataSignal.emit(itemCurrentId, dataTreeModel.getDataObj())
+                    dataTreeModel = item.getDataTreeModel(sequenceDataIndex)
+                    if dataTreeModel is not None:
+                        self.unregisterDataSignal.emit(itemCurrentId, dataTreeModel.getDataObj())
 
     @Slot()
     def deleteAllWriters(self):
@@ -500,8 +717,21 @@ class TesterModel(QAbstractListModel):
             return
         logging.trace(f"Delete Writer pressed on index: {str(currentIndex)}")
         mId = list(self.items.keys())[int(currentIndex)]
+        deletedDataItemIds = set()
+        item = self.items.get(mId)
+        if isinstance(item, WriterItem):
+            deletedDataItemIds.update(item.getDataItemIds())
         self.beginResetModel()
         del self.items[mId]
+        for sequenceItem in self.items.values():
+            if not isinstance(sequenceItem, SequenceItem):
+                continue
+            sequenceItem.beginResetModel()
+            sequenceItem.sequenceItems = [
+                reference for reference in sequenceItem.sequenceItems
+                if reference not in deletedDataItemIds
+            ]
+            sequenceItem.endResetModel()
         for key in self.threads.keys():
             self.threads[key].deleteWriter(mId)
         self.endResetModel()
@@ -524,15 +754,28 @@ class TesterModel(QAbstractListModel):
                 topicType = preset.get("topic_type", "")
                 domainId = preset.get("domain_id", 0)
                 topicName = preset.get("topic_name", "")
-                msgDict = preset.get("message", {"root": {}})["root"]
                 qos = preset.get("qos", {})
-                rootNode = self.dataModelHandler.getRootNode(topicType)
-                dataTreeModel = DataTreeModel(rootNode, parent=self)
-                if len(msgDict.keys()) > 0:
-                    dataTreeModel.fromJson(msgDict, self.dataModelHandler)
+                firstMessage = preset.get("message", {"root": {}})
+                additionalMessages = preset.get("messages", [])
+
+                messages = [firstMessage] + additionalMessages
+
+                dataTreeModels = []
+                messageNames = []
+                dataItemIds = []
+                for index, message in enumerate(messages):
+                    messageRoot = message.get("root", {}) if isinstance(message, dict) else {}
+                    dataTreeModels.append(self._createDataTreeModel(topicType, messageRoot))
+                    messageName = message.get("name", "") if isinstance(message, dict) else ""
+                    messageNames.append(messageName or f"Data {index + 1}")
+                    if index == 0:
+                        dataItemIds.append(_id)
+                    else:
+                        messageId = message.get("id", "") if isinstance(message, dict) else ""
+                        dataItemIds.append(messageId or str(uuid.uuid4()))
 
                 self.beginResetModel()
-                self.items[_id] = WriterItem(domainId, topicName, topicType, None, None, dataTreeModel, presetName, copy.deepcopy(qos), description)
+                self.items[_id] = WriterItem(_id, domainId, topicName, topicType, None, None, dataTreeModels, presetName, copy.deepcopy(qos), description, messageNames, dataItemIds)
                 self.endResetModel()
                 self.countChanged.emit()
 
@@ -542,8 +785,10 @@ class TesterModel(QAbstractListModel):
                 presetName = sequencePreset.get("preset_name", "Unknown")
                 description = sequencePreset.get("description", "")
                 sequenceItem = SequenceItem(presetName, description)
-                for itemSeqId in sequencePreset.get("sequence_items", []):
-                    sequenceItem.addSequenceItem(itemSeqId)
+                for sequenceReference in sequencePreset.get("sequence_items", []):
+                    dataItemId = self._getImportedSequenceDataItemId(sequenceReference)
+                    if dataItemId:
+                        sequenceItem.addSequenceItem(dataItemId)
 
                 self.beginResetModel()
                 self.items[mId] = sequenceItem
@@ -586,6 +831,12 @@ class TesterModel(QAbstractListModel):
                     "sequence_items": item.sequenceItems
                 })
         if isinstance(item, WriterItem):
+            messages = []
+            for index, dataTreeModel in enumerate(item.getDataTreeModels()):
+                message = dataTreeModel.toJson()
+                message["id"] = item.getDataItemId(index)
+                message["name"] = item.getDataItemName(index)
+                messages.append(message)
             self.exportData["presets"].append({
                     "id": mId,
                     "preset_name": item.getPresetName(),
@@ -593,7 +844,8 @@ class TesterModel(QAbstractListModel):
                     "domain_id": item.getDomainId(),
                     "topic_name": item.getTopicName(),
                     "topic_type": item.getTopicType(),
-                    "message": item.getDataTreeModel().toJson(),
+                    "message": messages[0],
+                    "messages": messages[1:],
                     "qos": item.qos
                 })
 
@@ -616,11 +868,15 @@ class TesterModel(QAbstractListModel):
         if isinstance(item, WriterItem):
             newId = str(uuid.uuid4())
             newPresetName = f"{item.getPresetName()}-copy"
-            rootNode = self.dataModelHandler.getRootNode(item.getTopicType())
-            dataTreeModel = DataTreeModel(rootNode, parent=self)
-            dataTreeModel.fromJson(item.getDataTreeModel().toJson()["root"], self.dataModelHandler)
+            dataTreeModels = [
+                self._createDataTreeModel(item.getTopicType(), dataTreeModel.toJson()["root"])
+                for dataTreeModel in item.getDataTreeModels()
+            ]
             self.beginResetModel()
-            self.items[newId] = WriterItem(item.getDomainId(), item.getTopicName(), item.getTopicType(), item.getQmlCode(), None, dataTreeModel, newPresetName, copy.deepcopy(item.qos), item.getDescription())
+            duplicateDataItemIds = [newId] + [
+                str(uuid.uuid4()) for _ in item.getDataTreeModels()[1:]
+            ]
+            self.items[newId] = WriterItem(newId, item.getDomainId(), item.getTopicName(), item.getTopicType(), item.getQmlCode(), None, dataTreeModels, newPresetName, copy.deepcopy(item.qos), item.getDescription(), item.getDataItemNames(), duplicateDataItemIds)
             self.endResetModel()
             self.countChanged.emit()
         elif isinstance(item, SequenceItem):
@@ -628,8 +884,8 @@ class TesterModel(QAbstractListModel):
             newPresetName = f"{item.getPresetName()}-copy"
             self.beginResetModel()
             newSequenceItem = SequenceItem(newPresetName, item.getDescription())
-            for itemSeqId in item.sequenceItems:
-                newSequenceItem.addSequenceItem(itemSeqId)
+            for dataItemId in item.sequenceItems:
+                newSequenceItem.addSequenceItem(dataItemId)
             self.items[newId] = newSequenceItem
             self.endResetModel()
             self.countChanged.emit()

--- a/src/models/tester_model.py
+++ b/src/models/tester_model.py
@@ -37,10 +37,11 @@ class SequenceItem(QAbstractListModel):
 
     NameRole = Qt.UserRole + 1
 
-    def __init__(self, presetName, parent=QObject()):
+    def __init__(self, presetName, description="", parent=QObject()):
         super().__init__(parent)
         self.currentlyModifing = False
         self.presetName = presetName
+        self.description = description
         self.sequenceItems = []
 
     def data(self, index: QModelIndex, role: int = Qt.DisplayRole):
@@ -67,6 +68,12 @@ class SequenceItem(QAbstractListModel):
     def setPresetName(self, presetName):
         self.presetName = presetName
 
+    def getDescription(self):
+        return self.description
+
+    def setDescription(self, description):
+        self.description = description
+
     def isPresetSequence(self):
         return self.dataTreeModel.rootNode.role == DataTreeModel.IsSequenceRole
 
@@ -85,7 +92,7 @@ class SequenceItem(QAbstractListModel):
         self.endResetModel()
 
 class WriterItem:
-    def __init__(self, domainId, topic_name, topic_type, qmlCode, pyCode, dataTreeModel, presetName, qos={}):
+    def __init__(self, domainId, topic_name, topic_type, qmlCode, pyCode, dataTreeModel, presetName, qos={}, description=""):
         self.domainId = domainId
         self.topic_name = topic_name
         self.topic_type = topic_type
@@ -93,6 +100,7 @@ class WriterItem:
         self.pyCode = pyCode
         self.dataTreeModel = dataTreeModel
         self.presetName = presetName
+        self.description = description
         self.qos = qos
         self.isStarted = False
 
@@ -101,6 +109,12 @@ class WriterItem:
 
     def setPresetName(self, presetName):
         self.presetName = presetName
+
+    def getDescription(self):
+        return self.description
+
+    def setDescription(self, description):
+        self.description = description
 
     def getTopicName(self):
         return self.topic_name
@@ -182,10 +196,7 @@ class TesterModel(QAbstractListModel):
         if role == self.PresetNameRole:
             return item.getPresetName()
         if role == self.DescriptionRole:
-            if isinstance(item, SequenceItem):
-                return "Sequence"
-            else:
-                return f"Topic: {item.getTopicName()}, Domain: {str(item.getDomainId())}"
+            return item.getDescription()
         if role == self.IsWriterRole:
             return isinstance(item, WriterItem)
         
@@ -233,14 +244,14 @@ class TesterModel(QAbstractListModel):
 
     @Slot(int, result=str)
     def getDescriptionName(self, currentIndex: int) -> str:
-        if currentIndex < 0:
-            return
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return ""
         mId = list(self.items.keys())[int(currentIndex)]
         item = self.items[mId]
         if isinstance(item, SequenceItem):
             return "Sequence"
         else:
-            return f"Topic: {item.getTopicName()}, Domain: {str(item.getDomainId())}"
+            return f"Topic: {item.getTopicName()}  |  Type: {item.getTopicType()}  |  Domain: {item.getDomainId()}"
 
     @Slot(int, result=bool)
     def getIsStarted(self, currentIndex: int) -> bool:
@@ -334,6 +345,23 @@ class TesterModel(QAbstractListModel):
         item.setPresetName(presetName)
         idx = self.index(currentIndex)
         self.dataChanged.emit(idx, idx, [self.PresetNameRole, self.NameRole])
+
+    @Slot(int, result=str)
+    def getDescription(self, currentIndex: int) -> str:
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return ""
+        mId = list(self.items.keys())[int(currentIndex)]
+        return self.items[mId].getDescription()
+
+    @Slot(int, str)
+    def setDescription(self, currentIndex: int, description: str):
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return
+        mId = list(self.items.keys())[int(currentIndex)]
+        item = self.items[mId]
+        item.setDescription(description)
+        idx = self.index(currentIndex)
+        self.dataChanged.emit(idx, idx, [self.DescriptionRole])
 
     @Slot(int, str, str, str, object)
     def addWriter(self, id: str, domainId, topic_name, topic_type: str, qos):
@@ -492,6 +520,7 @@ class TesterModel(QAbstractListModel):
             for preset in presets:
                 _id = preset.get("id", str(uuid.uuid4()))
                 presetName = preset.get("preset_name", "Unknown")
+                description = preset.get("description", "")
                 topicType = preset.get("topic_type", "")
                 domainId = preset.get("domain_id", 0)
                 topicName = preset.get("topic_name", "")
@@ -503,7 +532,7 @@ class TesterModel(QAbstractListModel):
                     dataTreeModel.fromJson(msgDict, self.dataModelHandler)
 
                 self.beginResetModel()
-                self.items[_id] = WriterItem(domainId, topicName, topicType, None, None, dataTreeModel, presetName, copy.deepcopy(qos))
+                self.items[_id] = WriterItem(domainId, topicName, topicType, None, None, dataTreeModel, presetName, copy.deepcopy(qos), description)
                 self.endResetModel()
                 self.countChanged.emit()
 
@@ -511,7 +540,8 @@ class TesterModel(QAbstractListModel):
             for sequencePreset in sequence_presets:
                 mId = sequencePreset.get("id", str(uuid.uuid4()))
                 presetName = sequencePreset.get("preset_name", "Unknown")
-                sequenceItem = SequenceItem(presetName)
+                description = sequencePreset.get("description", "")
+                sequenceItem = SequenceItem(presetName, description)
                 for itemSeqId in sequencePreset.get("sequence_items", []):
                     sequenceItem.addSequenceItem(itemSeqId)
 
@@ -552,12 +582,14 @@ class TesterModel(QAbstractListModel):
             self.exportData["sequence_presets"].append({
                     "id": mId,
                     "preset_name": item.getPresetName(),
+                    "description": item.getDescription(),
                     "sequence_items": item.sequenceItems
                 })
         if isinstance(item, WriterItem):
             self.exportData["presets"].append({
                     "id": mId,
                     "preset_name": item.getPresetName(),
+                    "description": item.getDescription(),
                     "domain_id": item.getDomainId(),
                     "topic_name": item.getTopicName(),
                     "topic_type": item.getTopicType(),
@@ -588,14 +620,14 @@ class TesterModel(QAbstractListModel):
             dataTreeModel = DataTreeModel(rootNode, parent=self)
             dataTreeModel.fromJson(item.getDataTreeModel().toJson()["root"], self.dataModelHandler)
             self.beginResetModel()
-            self.items[newId] = WriterItem(item.getDomainId(), item.getTopicName(), item.getTopicType(), item.getQmlCode(), None, dataTreeModel, newPresetName, copy.deepcopy(item.qos))
+            self.items[newId] = WriterItem(item.getDomainId(), item.getTopicName(), item.getTopicType(), item.getQmlCode(), None, dataTreeModel, newPresetName, copy.deepcopy(item.qos), item.getDescription())
             self.endResetModel()
             self.countChanged.emit()
         elif isinstance(item, SequenceItem):
             newId = str(uuid.uuid4())
             newPresetName = f"{item.getPresetName()}-copy"
             self.beginResetModel()
-            newSequenceItem = SequenceItem(newPresetName)
+            newSequenceItem = SequenceItem(newPresetName, item.getDescription())
             for itemSeqId in item.sequenceItems:
                 newSequenceItem.addSequenceItem(itemSeqId)
             self.items[newId] = newSequenceItem

--- a/src/translations/cyclonedds-insight_de.ts
+++ b/src/translations/cyclonedds-insight_de.ts
@@ -250,6 +250,15 @@
     <message id="tester.create-sequence">
         <translation>Sequence erstellen</translation>
     </message>
+    <message id="tester.description">
+        <translation>Beschreibung:</translation>
+    </message>
+    <message id="tester.description.collapse">
+        <translation>Beschreibung einklappen</translation>
+    </message>
+    <message id="tester.description.placeholder">
+        <translation>Dieses Preset beschreiben...</translation>
+    </message>
 
 </context>
 </TS>

--- a/src/translations/cyclonedds-insight_en.ts
+++ b/src/translations/cyclonedds-insight_en.ts
@@ -244,6 +244,15 @@
     <message id="tester.create-sequence">
         <translation>Create Sequence</translation>
     </message>
+    <message id="tester.description">
+        <translation>Description:</translation>
+    </message>
+    <message id="tester.description.collapse">
+        <translation>Collapse description</translation>
+    </message>
+    <message id="tester.description.placeholder">
+        <translation>Describe this preset...</translation>
+    </message>
 
 </context>
 </TS>

--- a/src/views/DataModelOverview.qml
+++ b/src/views/DataModelOverview.qml
@@ -17,6 +17,7 @@ import QtQuick.Layouts
 import QtQuick.Dialogs
 
 import org.eclipse.cyclonedds.insight
+import "qrc:/src/views/icons"
 
 
 Rectangle {
@@ -65,10 +66,15 @@ Rectangle {
                     onClicked: clearDialog.open()
                 }
                 Button {
-                    text: "\u{1F50D}"
                     flat: true
                     highlighted: searchField.visible
                     Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                    SearchIcon {
+                        anchors.centerIn: parent
+                        z: 1
+                        expanded: searchField.visible
+                        iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                    }
                     onClicked: {
                         if (searchField.visible) {
                             searchField.clear()

--- a/src/views/HeaderToolBar.qml
+++ b/src/views/HeaderToolBar.qml
@@ -19,11 +19,15 @@ import org.eclipse.cyclonedds.insight
 import "qrc:/src/views/icons"
 
 ToolBar {
+    id: headerToolBar
     topPadding: 10
     bottomPadding: 10
     leftPadding: 10
     rightPadding: 10
-    property bool isHeaderSpinning: false
+    property bool isStartupSpinning: true
+    property int startupSpinLoops: 0
+    property bool isActivitySpinning: false
+    readonly property bool isHeaderSpinning: isStartupSpinning || isActivitySpinning
 
     background: Rectangle {
         anchors.fill: parent
@@ -33,7 +37,7 @@ ToolBar {
     Connections {
         target: treeModel
         function onDiscover_domains_running_signal(active) {
-            isHeaderSpinning = active;
+            headerToolBar.isActivitySpinning = active
         }
     }
 
@@ -60,6 +64,17 @@ ToolBar {
                 sourceSize.width: 30
                 height: 30
                 width: 30
+
+                onCurrentFrameChanged: {
+                    if (headerToolBar.isStartupSpinning
+                            && frameCount > 1
+                            && currentFrame === frameCount - 1) {
+                        headerToolBar.startupSpinLoops++
+                        if (headerToolBar.startupSpinLoops >= 2) {
+                            headerToolBar.isStartupSpinning = false
+                        }
+                    }
+                }
             }
         }
 

--- a/src/views/HeaderToolBar.qml
+++ b/src/views/HeaderToolBar.qml
@@ -29,6 +29,12 @@ ToolBar {
     property bool isActivitySpinning: false
     readonly property bool isHeaderSpinning: isStartupSpinning || isActivitySpinning
 
+    function startLogoSpin() {
+        startupSpinLoops = 0
+        isStartupSpinning = true
+        headerLoadingId.currentFrame = 0
+    }
+
     background: Rectangle {
         anchors.fill: parent
         color: rootWindow.isDarkMode ? Constants.darkHeaderBackground : Constants.lightHeaderBackground
@@ -75,6 +81,11 @@ ToolBar {
                         }
                     }
                 }
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: headerToolBar.startLogoSpin()
             }
         }
 

--- a/src/views/HeaderToolBar.qml
+++ b/src/views/HeaderToolBar.qml
@@ -16,6 +16,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import org.eclipse.cyclonedds.insight
+import "qrc:/src/views/icons"
 
 ToolBar {
     topPadding: 10
@@ -79,10 +80,16 @@ ToolBar {
         }
         ToolButton {
             id: menuButton
-            text: "\u2630"
             onClicked: menu.open()
             flat: true
-            font.pixelSize: 15
+
+            MenuIcon {
+                anchors.centerIn: parent
+                width: 18
+                height: 18
+                z: 1
+                iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+            }
 
             Menu {
                 id: menu

--- a/src/views/ParticipantsOverview.qml
+++ b/src/views/ParticipantsOverview.qml
@@ -16,6 +16,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import org.eclipse.cyclonedds.insight
+import "qrc:/src/views/icons"
 
 
 TreeView {
@@ -68,22 +69,6 @@ TreeView {
         required property int column
         required property bool current
 
-        // Rotate indicator when expanded by the user
-        // (requires TreeView to have a selectionModel)
-        property Animation indicatorAnimation: NumberAnimation {
-            target: indicator
-            property: "rotation"
-            from: expanded ? 0 : 90
-            to: expanded ? 90 : 0
-            duration: 100
-            easing.type: Easing.OutQuart
-        }
-        TableView.onPooled: indicatorAnimation.complete()
-        TableView.onReused: if (current) indicatorAnimation.start()
-        onExpandedChanged: {
-            indicator.rotation = expanded ? 90 : 0
-        }
-
         Rectangle {
             id: background
             height: parent.height
@@ -94,12 +79,15 @@ TreeView {
             radius: 5
         }
 
-        Label {
+        ChevronIcon {
             id: indicator
+            width: 14
+            height: 14
             x: padding + (depth * indentation)
             anchors.verticalCenter: parent.verticalCenter
             visible: isTreeNode && hasChildren
-            text: "▶"
+            iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+            direction: expanded ? "down" : "right"
 
             TapHandler {
                 onSingleTapped: {

--- a/src/views/SideView.qml
+++ b/src/views/SideView.qml
@@ -16,6 +16,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 
 import org.eclipse.cyclonedds.insight
+import "qrc:/src/views/icons"
 
 
 ColumnLayout {
@@ -107,11 +108,16 @@ ColumnLayout {
             }
         }
         Button {
-            text: "\u{1F50D}"
             flat: true
             highlighted: searchField.visible
             visible: viewSelector.currentIndex === 0
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+            SearchIcon {
+                anchors.centerIn: parent
+                z: 1
+                expanded: searchField.visible
+                iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+            }
             onClicked: {
                 if (viewSelector.currentIndex === 0) {
                     if (searchField.visible) {

--- a/src/views/TesterView.qml
+++ b/src/views/TesterView.qml
@@ -30,7 +30,24 @@ Rectangle {
     property var sequenceModel: null
     property bool isSequenceEditorVisible: false
     property bool isDescriptionExpanded: false
+    property int currentDataIndex: 0
     property int testerRev: 0
+
+    function refreshCurrentModels() {
+        if (!testerModel || librariesCombobox.currentIndex < 0) {
+            dataTreeModel = null
+            sequenceModel = null
+            currentDataIndex = 0
+            return
+        }
+
+        const dataItemCount = testerModel.getDataItemCount(librariesCombobox.currentIndex)
+        currentDataIndex = dataItemCount > 0
+                ? Math.min(currentDataIndex, dataItemCount - 1)
+                : 0
+        dataTreeModel = testerModel.getTreeModel(librariesCombobox.currentIndex, currentDataIndex)
+        sequenceModel = testerModel.getSequenceModel(librariesCombobox.currentIndex)
+    }
 
     Connections {
         target: testerModel
@@ -201,9 +218,6 @@ Rectangle {
                                 onClicked: {
                                     librariesCombobox.currentIndex = index
                                     librariesCombobox.popup.close()
-
-                                    dataTreeModel = testerModel.getTreeModel(index)
-                                    sequenceModel = testerModel.getSequenceModel(index)
                                 }
                             }
                         }
@@ -221,8 +235,8 @@ Rectangle {
 
                 onCurrentIndexChanged: {
                     if (testerModel && currentIndex >= 0) {
-                        dataTreeModel = testerModel.getTreeModel(currentIndex)
-                        sequenceModel = testerModel.getSequenceModel(currentIndex)
+                        currentDataIndex = 0
+                        refreshCurrentModels()
                         descriptionField.text = testerModel.getDescription(currentIndex)
                     }
                 }
@@ -425,6 +439,201 @@ Rectangle {
             }
         }
 
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.leftMargin: 3
+            Layout.rightMargin: 3
+            visible: dataTreeModel !== null && sequenceModel === null
+            spacing: 3
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 29
+                color: "transparent"
+
+                Rectangle {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    height: 1
+                    color: rootWindow.isDarkMode ? Constants.darkSeparator : Constants.lightSeparator
+                }
+
+                ListView {
+                    id: dataItemTabList
+                    anchors.fill: parent
+                    orientation: ListView.Horizontal
+                    spacing: 2
+                    clip: true
+                    model: (testerRev, testerModel.getDataItemCount(librariesCombobox.currentIndex))
+                    currentIndex: currentDataIndex
+
+                    delegate: Rectangle {
+                        id: dataItemTab
+                        required property int index
+                        property bool selected: index === currentDataIndex
+                        width: Math.max(76, Math.min(180, tabNameLabel.implicitWidth + 24))
+                        height: selected ? 29 : 26
+                        y: selected ? 0 : 3
+                        radius: 5
+                        color: selected
+                               ? (rootWindow.isDarkMode ? Constants.darkMainContent : Constants.lightMainContent)
+                               : (rootWindow.isDarkMode ? Constants.darkCardBackgroundColor : Constants.lightCardBackgroundColor)
+                        border.width: 1
+                        border.color: rootWindow.isDarkMode ? Constants.darkSeparator : Constants.lightSeparator
+                        opacity: selected || dataItemTabMouseArea.containsMouse ? 1 : 0.75
+
+                        Rectangle {
+                            visible: selected
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.bottom: parent.bottom
+                            anchors.leftMargin: 1
+                            anchors.rightMargin: 1
+                            height: 2
+                            color: parent.color
+                        }
+
+                        Label {
+                            id: tabNameLabel
+                            anchors.left: parent.left
+                            anchors.right: parent.right
+                            anchors.leftMargin: 12
+                            anchors.rightMargin: 12
+                            anchors.verticalCenter: parent.verticalCenter
+                            visible: !tabNameEditor.visible
+                            text: (testerRev, testerModel.getDataItemName(librariesCombobox.currentIndex, index))
+                            font.bold: selected
+                            elide: Text.ElideRight
+                        }
+
+                        TextField {
+                            id: tabNameEditor
+                            anchors.fill: parent
+                            visible: false
+                            text: tabNameLabel.text
+                            selectByMouse: true
+                            leftPadding: 6
+                            rightPadding: 6
+
+                            function finishEditing() {
+                                testerModel.setDataItemName(librariesCombobox.currentIndex, index, text)
+                                visible = false
+                                testerRev++
+                            }
+
+                            onAccepted: finishEditing()
+                            onActiveFocusChanged: {
+                                if (!activeFocus && visible) {
+                                    finishEditing()
+                                }
+                            }
+                            Keys.onEscapePressed: {
+                                text = tabNameLabel.text
+                                visible = false
+                            }
+                        }
+
+                        MouseArea {
+                            id: dataItemTabMouseArea
+                            anchors.fill: parent
+                            enabled: !tabNameEditor.visible
+                            acceptedButtons: Qt.LeftButton
+                            hoverEnabled: true
+                            cursorShape: Qt.PointingHandCursor
+                            onClicked: {
+                                currentDataIndex = index
+                                refreshCurrentModels()
+                            }
+                            onDoubleClicked: {
+                                currentDataIndex = index
+                                tabNameEditor.text = tabNameLabel.text
+                                tabNameEditor.visible = true
+                                tabNameEditor.forceActiveFocus()
+                                tabNameEditor.selectAll()
+                            }
+                        }
+
+                        ToolTip {
+                            id: dataItemTabTooltip
+                            parent: dataItemTab
+                            visible: dataItemTabMouseArea.containsMouse && !tabNameEditor.visible
+                            delay: 500
+                            text: "Double-click to rename"
+                            contentItem: Label {
+                                text: dataItemTabTooltip.text
+                            }
+                            background: Rectangle {
+                                border.color: rootWindow.isDarkMode ? Constants.darkBorderColor : Constants.lightBorderColor
+                                border.width: 1
+                                color: rootWindow.isDarkMode ? Constants.darkCardBackgroundColor : Constants.lightCardBackgroundColor
+                            }
+                        }
+                    }
+                }
+            }
+
+            ToolButton {
+                id: addDataItemButton
+                implicitWidth: 26
+                implicitHeight: 26
+                onClicked: {
+                    const newIndex = testerModel.addDataItem(librariesCombobox.currentIndex)
+                    if (newIndex >= 0) {
+                        currentDataIndex = newIndex
+                        testerRev++
+                        refreshCurrentModels()
+                    }
+                }
+
+                Item {
+                    anchors.centerIn: parent
+                    width: 14
+                    height: 14
+                    z: 1
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: parent.width
+                        height: 2
+                        radius: 1
+                        color: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                    }
+
+                    Rectangle {
+                        anchors.centerIn: parent
+                        width: 2
+                        height: parent.height
+                        radius: 1
+                        color: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                    }
+                }
+            }
+
+            ToolButton {
+                implicitWidth: 26
+                implicitHeight: 26
+                enabled: (testerRev, testerModel.getDataItemCount(librariesCombobox.currentIndex) > 1)
+                onClicked: {
+                    currentDataIndex = testerModel.removeDataItem(
+                                librariesCombobox.currentIndex, currentDataIndex)
+                    testerRev++
+                    refreshCurrentModels()
+                }
+
+                Rectangle {
+                    anchors.centerIn: parent
+                    width: 14
+                    height: 2
+                    radius: 1
+                    z: 1
+                    color: parent.enabled
+                           ? (rootWindow.isDarkMode ? "#d0d0d0" : "#505050")
+                           : (rootWindow.isDarkMode ? "#606060" : "#a0a0a0")
+                }
+            }
+        }
+
        Rectangle {
             id: contentRec
             color: rootWindow.isDarkMode ? Constants.darkMainContent : Constants.lightMainContent
@@ -465,14 +674,14 @@ Rectangle {
                             id: availableList
                             anchors.fill: parent
                             clip: true
-                            model: testerModel
+                            model: (testerRev, testerModel.getAvailableDataItemCount())
                             currentIndex: sequenceEditor.availableIndex
                             onCurrentIndexChanged: sequenceEditor.availableIndex = currentIndex
 
                             delegate: ItemDelegate {
-                                enabled: model.isWriter
+                                required property int index
                                 width: ListView.view.width
-                                text: model.name
+                                text: (testerRev, testerModel.getAvailableDataItemName(index))
                                 highlighted: index === availableList.currentIndex
                                 onClicked: availableList.currentIndex = index
                             }
@@ -511,7 +720,8 @@ Rectangle {
                             }
                             onClicked: {
                                 if (testerModel && sequenceModel) {
-                                    sequenceModel.addSequenceItem(testerModel.getItemId(availableList.currentIndex))
+                                    sequenceModel.addSequenceItem(
+                                                testerModel.getAvailableDataItemId(availableList.currentIndex))
                                     testerRev++
                                 }
                             }
@@ -564,8 +774,10 @@ Rectangle {
                             currentIndex: sequenceEditor.sequenceIndex
 
                             delegate: ItemDelegate {
+                                required property int index
+                                required property string dataItemId
                                 width: ListView.view.width
-                                text: testerModel.getNameById(name)
+                                text: (testerRev, testerModel.getDataItemDisplayName(dataItemId))
                                 highlighted: index === sequenceList.currentIndex
                                 onClicked: sequenceList.currentIndex = index
                             }
@@ -744,7 +956,9 @@ Rectangle {
                         anchors.leftMargin: 5
                         text: "+"
                         onClicked: {
-                            testerModel.addArrayItem(librariesCombobox.currentIndex, treeView.index(row, column))
+                            testerModel.addArrayItem(librariesCombobox.currentIndex,
+                                                     currentDataIndex,
+                                                     treeView.index(row, column))
                         }
                     }
                     Button {
@@ -754,7 +968,9 @@ Rectangle {
                         anchors.leftMargin: 5
                         text: "-"
                         onClicked: {
-                            testerModel.removeArrayItem(librariesCombobox.currentIndex, treeView.index(row, column))
+                            testerModel.removeArrayItem(librariesCombobox.currentIndex,
+                                                        currentDataIndex,
+                                                        treeView.index(row, column))
                         }
                     }
                 }
@@ -778,7 +994,7 @@ Rectangle {
                 visible: testerModel.count > 0
                 onClicked: {
                     console.log("Write Button clicked")
-                    testerModel.writeData(librariesCombobox.currentIndex)
+                    testerModel.writeData(librariesCombobox.currentIndex, currentDataIndex)
                 }
             }
             Item {
@@ -789,7 +1005,7 @@ Rectangle {
                 visible: testerModel.count > 0
                 onClicked: {
                     console.log("Dispose Button clicked")
-                    testerModel.disposeData(librariesCombobox.currentIndex)
+                    testerModel.disposeData(librariesCombobox.currentIndex, currentDataIndex)
                 }
             }
             Button {
@@ -797,7 +1013,7 @@ Rectangle {
                 visible: testerModel.count > 0
                 onClicked: {
                     console.log("Unregister Button clicked")
-                    testerModel.unregisterData(librariesCombobox.currentIndex)
+                    testerModel.unregisterData(librariesCombobox.currentIndex, currentDataIndex)
                 }
             }
         }

--- a/src/views/TesterView.qml
+++ b/src/views/TesterView.qml
@@ -487,8 +487,28 @@ Rectangle {
                         spacing: 8
 
                         Button {
-                            text: "Add →"
+                            id: addSequenceItemButton
                             enabled: availableList.currentIndex >= 0
+                            implicitWidth: addSequenceItemContent.implicitWidth + leftPadding + rightPadding
+
+                            Row {
+                                id: addSequenceItemContent
+                                anchors.centerIn: parent
+                                z: 1
+                                spacing: 5
+
+                                Label {
+                                    text: "Add"
+                                    color: addSequenceItemButton.enabled ? addSequenceItemButton.palette.buttonText : addSequenceItemButton.palette.mid
+                                }
+
+                                ArrowIcon {
+                                    width: 18
+                                    height: 18
+                                    y: (parent.height - height) / 2
+                                    iconColor: addSequenceItemButton.enabled ? addSequenceItemButton.palette.buttonText : addSequenceItemButton.palette.mid
+                                }
+                            }
                             onClicked: {
                                 if (testerModel && sequenceModel) {
                                     sequenceModel.addSequenceItem(testerModel.getItemId(availableList.currentIndex))
@@ -498,8 +518,29 @@ Rectangle {
                         }
 
                         Button {
-                            text: "← Remove"
+                            id: removeSequenceItemButton
                             enabled: sequenceList.currentIndex >= 0
+                            implicitWidth: removeSequenceItemContent.implicitWidth + leftPadding + rightPadding
+
+                            Row {
+                                id: removeSequenceItemContent
+                                anchors.centerIn: parent
+                                z: 1
+                                spacing: 5
+
+                                ArrowIcon {
+                                    width: 18
+                                    height: 18
+                                    y: (parent.height - height) / 2
+                                    direction: "left"
+                                    iconColor: removeSequenceItemButton.enabled ? removeSequenceItemButton.palette.buttonText : removeSequenceItemButton.palette.mid
+                                }
+
+                                Label {
+                                    text: "Remove"
+                                    color: removeSequenceItemButton.enabled ? removeSequenceItemButton.palette.buttonText : removeSequenceItemButton.palette.mid
+                                }
+                            }
                             onClicked: {
                                 if (sequenceModel) {
                                     sequenceModel.removeSequenceItem(sequenceList.currentIndex)
@@ -566,20 +607,6 @@ Rectangle {
                     required property int column
                     required property bool current
 
-                    property Animation indicatorAnimation: NumberAnimation {
-                        target: indicator
-                        property: "rotation"
-                        from: expanded ? 0 : 90
-                        to: expanded ? 90 : 0
-                        duration: 100
-                        easing.type: Easing.OutQuart
-                    }
-                    TableView.onPooled: indicatorAnimation.complete()
-                    TableView.onReused: if (current) indicatorAnimation.start()
-                    onExpandedChanged: {
-                        indicator.rotation = expanded ? 90 : 0
-                    }
-
                     Rectangle {
                         id: background
                         anchors.fill: parent
@@ -589,12 +616,15 @@ Rectangle {
                         radius: 5
                     }
 
-                    Label {
+                    ChevronIcon {
                         id: indicator
+                        width: 14
+                        height: 14
                         x: padding + (depth * indentation)
                         anchors.verticalCenter: parent.verticalCenter
                         visible: isTreeNode && hasChildren
-                        text: "▶"
+                        iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                        direction: expanded ? "down" : "right"
 
                         TapHandler {
                             onSingleTapped: {

--- a/src/views/TesterView.qml
+++ b/src/views/TesterView.qml
@@ -18,6 +18,7 @@ import QtQuick.Layouts
 import QtQuick.Dialogs
 
 import org.eclipse.cyclonedds.insight
+import "qrc:/src/views/icons"
 
 
 Rectangle {
@@ -28,6 +29,7 @@ Rectangle {
     property var dataTreeModel: null
     property var sequenceModel: null
     property bool isSequenceEditorVisible: false
+    property bool isDescriptionExpanded: false
     property int testerRev: 0
 
     Connections {
@@ -221,6 +223,7 @@ Rectangle {
                     if (testerModel && currentIndex >= 0) {
                         dataTreeModel = testerModel.getTreeModel(currentIndex)
                         sequenceModel = testerModel.getSequenceModel(currentIndex)
+                        descriptionField.text = testerModel.getDescription(currentIndex)
                     }
                 }
 
@@ -272,29 +275,132 @@ Rectangle {
             }
         }
 
-        RowLayout {
+        ColumnLayout {
             Layout.fillWidth: true
-            Layout.preferredHeight: 10
             visible: testerModel.count > 0
+            spacing: 4
 
-            Label {
-                text: testerModel.getDescriptionName(librariesCombobox.currentIndex)
-                leftPadding: 10
-                topPadding: 5
-            }
-
-            Item {
+            RowLayout {
                 Layout.fillWidth: true
-                Layout.preferredHeight: 1
+                spacing: 10
+
+                Label {
+                    Layout.leftMargin: 10
+                    Layout.fillWidth: true
+                    text: testerModel.getDescriptionName(librariesCombobox.currentIndex)
+                    wrapMode: Text.Wrap
+                }
+
+                Button {
+                    Layout.rightMargin: 1
+                    text: (testerRev, testerModel.getIsStarted(librariesCombobox.currentIndex)) ? "Stop" : "Start"
+                    onClicked: {
+                        if (testerModel.getIsStarted(librariesCombobox.currentIndex)) {
+                            testerModel.stopItem(librariesCombobox.currentIndex)
+                        } else {
+                            testerModel.startItem(librariesCombobox.currentIndex)
+                        }
+                    }
+                }
             }
 
-            Button {
-                text: (testerRev, testerModel.getIsStarted(librariesCombobox.currentIndex)) ? "Stop" : "Start"
-                onClicked: {
-                    if (testerModel.getIsStarted(librariesCombobox.currentIndex)) {
-                        testerModel.stopItem(librariesCombobox.currentIndex)
-                    } else {
-                        testerModel.startItem(librariesCombobox.currentIndex)
+            RowLayout {
+                Layout.fillWidth: true
+                Layout.leftMargin: 10
+                Layout.rightMargin: 10
+                spacing: 8
+
+                Label {
+                    text: qsTrId("tester.description")
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                    implicitHeight: 26
+
+                    Label {
+                        id: descriptionPreview
+                        anchors.left: parent.left
+                        anchors.right: descriptionExpandIndicator.left
+                        anchors.rightMargin: 8
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: {
+                            const description = (testerRev, testerModel.getDescription(librariesCombobox.currentIndex))
+                            return description.length > 0 ? description : qsTrId("tester.description.placeholder")
+                        }
+                        opacity: (testerRev, testerModel.getDescription(librariesCombobox.currentIndex).length > 0) ? 1 : 0.55
+                        font.italic: (testerRev, testerModel.getDescription(librariesCombobox.currentIndex).length === 0)
+                        elide: Text.ElideRight
+                        maximumLineCount: 1
+                    }
+
+                    ChevronIcon {
+                        id: descriptionExpandIndicator
+                        width: 16
+                        height: 16
+                        anchors.right: parent.right
+                        anchors.verticalCenter: parent.verticalCenter
+                        iconColor: rootWindow.isDarkMode ? "#b0b0b0" : "#606060"
+                        rotation: isDescriptionExpanded ? 180 : 0
+                        opacity: 0.7
+
+                        Behavior on rotation {
+                            NumberAnimation {
+                                duration: 120
+                                easing.type: Easing.OutCubic
+                            }
+                        }
+                    }
+
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        height: 1
+                        color: rootWindow.isDarkMode ? Constants.darkSeparator : Constants.lightSeparator
+                        opacity: descriptionMouseArea.containsMouse ? 1 : 0.6
+                    }
+
+                    MouseArea {
+                        id: descriptionMouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        cursorShape: Qt.PointingHandCursor
+                        onClicked: {
+                            isDescriptionExpanded = !isDescriptionExpanded
+                            if (isDescriptionExpanded) {
+                                descriptionField.forceActiveFocus()
+                            }
+                        }
+                    }
+                }
+            }
+
+            ScrollView {
+                id: descriptionScrollView
+                visible: isDescriptionExpanded
+                Layout.fillWidth: true
+                Layout.leftMargin: 10
+                Layout.rightMargin: 10
+                Layout.preferredHeight: 80
+                Layout.minimumHeight: 80
+                Layout.maximumHeight: 120
+                clip: true
+
+                ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+                ScrollBar.vertical.policy: ScrollBar.AsNeeded
+
+                TextArea {
+                    id: descriptionField
+                    placeholderText: qsTrId("tester.description.placeholder")
+                    wrapMode: TextEdit.Wrap
+                    selectByMouse: true
+                    persistentSelection: true
+
+                    onTextChanged: {
+                        if (visible && testerModel && librariesCombobox.currentIndex >= 0) {
+                            testerModel.setDescription(librariesCombobox.currentIndex, text)
+                        }
                     }
                 }
             }

--- a/src/views/TopicOverview.qml
+++ b/src/views/TopicOverview.qml
@@ -60,22 +60,6 @@ TreeView {
         required property int column
         required property bool current
 
-        // Rotate indicator when expanded by the user
-        // (requires TreeView to have a selectionModel)
-        property Animation indicatorAnimation: NumberAnimation {
-            target: indicator
-            property: "rotation"
-            from: expanded ? 0 : 90
-            to: expanded ? 90 : 0
-            duration: 100
-            easing.type: Easing.OutQuart
-        }
-        TableView.onPooled: indicatorAnimation.complete()
-        TableView.onReused: if (current) indicatorAnimation.start()
-        onExpandedChanged: {
-            indicator.rotation = expanded ? 90 : 0
-        }
-
         Rectangle {
             id: background
             height: parent.height
@@ -86,12 +70,15 @@ TreeView {
             radius: 5
         }
 
-        Label {
+        ChevronIcon {
             id: indicator
+            width: 14
+            height: 14
             x: padding + (depth * indentation)
             anchors.verticalCenter: parent.verticalCenter
             visible: isTreeNode && hasChildren
-            text: "▶"
+            iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+            direction: expanded ? "down" : "right"
 
             TapHandler {
                 onSingleTapped: {
@@ -127,4 +114,3 @@ TreeView {
         return treeSelection.currentIndex
     }
 }
-

--- a/src/views/config_editor/ConfigEditorView.qml
+++ b/src/views/config_editor/ConfigEditorView.qml
@@ -20,6 +20,7 @@ import QtQuick.Dialogs
 import org.eclipse.cyclonedds.insight
 import "qrc:/src/views"
 import "qrc:/src/views/elements"
+import "qrc:/src/views/icons"
 
 Rectangle {
     id: settingsViewId
@@ -241,22 +242,6 @@ Rectangle {
                             required property int column
                             required property bool current
 
-                            // Rotate indicator when expanded by the user
-                            // (requires TreeView to have a selectionModel)
-                            property Animation indicatorAnimation: NumberAnimation {
-                                target: indicator
-                                property: "rotation"
-                                from: expanded ? 0 : 90
-                                to: expanded ? 90 : 0
-                                duration: 100
-                                easing.type: Easing.OutQuart
-                            }
-                            TableView.onPooled: indicatorAnimation.complete()
-                            TableView.onReused: if (current) indicatorAnimation.start()
-                            onExpandedChanged: {
-                                indicator.rotation = expanded ? 90 : 0
-                            }
-
                             Rectangle {
                                 id: background
                                 height: parent.height
@@ -267,12 +252,15 @@ Rectangle {
                                 radius: 5
                             }
 
-                            Label {
+                            ChevronIcon {
                                 id: indicator
+                                width: 14
+                                height: 14
                                 x: padding + (depth * indentation)
                                 anchors.verticalCenter: parent.verticalCenter
                                 visible: isTreeNode && hasChildren
-                                text: "▶"
+                                iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                                direction: expanded ? "down" : "right"
 
                                 TapHandler {
                                     onSingleTapped: {

--- a/src/views/icons/ArrowIcon.qml
+++ b/src/views/icons/ArrowIcon.qml
@@ -1,8 +1,14 @@
 /*
  * Copyright(c) 2024 Sven Trittler
  *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+*/
 
 import QtQuick
 

--- a/src/views/icons/ArrowIcon.qml
+++ b/src/views/icons/ArrowIcon.qml
@@ -1,0 +1,46 @@
+/*
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+import QtQuick
+
+Item {
+    id: root
+
+    property color iconColor: "grey"
+    property real lineWidth: 2.5
+    property string direction: "right"
+
+    implicitWidth: 20
+    implicitHeight: 20
+    rotation: direction === "down" ? 90
+              : direction === "left" ? 180
+              : direction === "up" ? 270
+              : 0
+
+    onIconColorChanged: arrowCanvas.requestPaint()
+    onLineWidthChanged: arrowCanvas.requestPaint()
+
+    Canvas {
+        id: arrowCanvas
+        anchors.fill: parent
+
+        onPaint: {
+            const context = getContext("2d")
+            context.clearRect(0, 0, width, height)
+            context.strokeStyle = root.iconColor
+            context.lineWidth = root.lineWidth
+            context.lineCap = "round"
+            context.lineJoin = "round"
+            context.beginPath()
+            context.moveTo(width * 0.14, height * 0.5)
+            context.lineTo(width * 0.84, height * 0.5)
+            context.moveTo(width * 0.56, height * 0.2)
+            context.lineTo(width * 0.86, height * 0.5)
+            context.lineTo(width * 0.56, height * 0.8)
+            context.stroke()
+        }
+    }
+}

--- a/src/views/icons/ChevronIcon.qml
+++ b/src/views/icons/ChevronIcon.qml
@@ -1,0 +1,39 @@
+/*
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+import QtQuick
+
+Item {
+    id: root
+
+    property color iconColor: "grey"
+    property real lineWidth: 1.5
+
+    implicitWidth: 16
+    implicitHeight: 16
+
+    onIconColorChanged: chevronCanvas.requestPaint()
+    onLineWidthChanged: chevronCanvas.requestPaint()
+
+    Canvas {
+        id: chevronCanvas
+        anchors.fill: parent
+
+        onPaint: {
+            const context = getContext("2d")
+            context.clearRect(0, 0, width, height)
+            context.beginPath()
+            context.moveTo(width * 0.22, height * 0.38)
+            context.lineTo(width * 0.5, height * 0.66)
+            context.lineTo(width * 0.78, height * 0.38)
+            context.lineWidth = root.lineWidth
+            context.lineCap = "round"
+            context.lineJoin = "round"
+            context.strokeStyle = root.iconColor
+            context.stroke()
+        }
+    }
+}

--- a/src/views/icons/ChevronIcon.qml
+++ b/src/views/icons/ChevronIcon.qml
@@ -11,12 +11,14 @@ Item {
 
     property color iconColor: "grey"
     property real lineWidth: 1.5
+    property string direction: "down"
 
     implicitWidth: 16
     implicitHeight: 16
 
     onIconColorChanged: chevronCanvas.requestPaint()
     onLineWidthChanged: chevronCanvas.requestPaint()
+    onDirectionChanged: chevronCanvas.requestPaint()
 
     Canvas {
         id: chevronCanvas
@@ -26,9 +28,15 @@ Item {
             const context = getContext("2d")
             context.clearRect(0, 0, width, height)
             context.beginPath()
-            context.moveTo(width * 0.22, height * 0.38)
-            context.lineTo(width * 0.5, height * 0.66)
-            context.lineTo(width * 0.78, height * 0.38)
+            if (root.direction === "right") {
+                context.moveTo(width * 0.38, height * 0.22)
+                context.lineTo(width * 0.66, height * 0.5)
+                context.lineTo(width * 0.38, height * 0.78)
+            } else {
+                context.moveTo(width * 0.22, height * 0.38)
+                context.lineTo(width * 0.5, height * 0.66)
+                context.lineTo(width * 0.78, height * 0.38)
+            }
             context.lineWidth = root.lineWidth
             context.lineCap = "round"
             context.lineJoin = "round"

--- a/src/views/icons/ChevronIcon.qml
+++ b/src/views/icons/ChevronIcon.qml
@@ -1,8 +1,14 @@
 /*
  * Copyright(c) 2024 Sven Trittler
  *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+*/
 
 import QtQuick
 

--- a/src/views/icons/MenuIcon.qml
+++ b/src/views/icons/MenuIcon.qml
@@ -1,0 +1,41 @@
+/*
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+import QtQuick
+
+Item {
+    id: root
+
+    property color iconColor: "grey"
+    property real lineWidth: 1.5
+
+    implicitWidth: 16
+    implicitHeight: 16
+
+    onIconColorChanged: menuCanvas.requestPaint()
+    onLineWidthChanged: menuCanvas.requestPaint()
+
+    Canvas {
+        id: menuCanvas
+        anchors.fill: parent
+
+        onPaint: {
+            const context = getContext("2d")
+            context.clearRect(0, 0, width, height)
+            context.strokeStyle = root.iconColor
+            context.lineWidth = root.lineWidth
+            context.lineCap = "round"
+
+            for (let row = 0; row < 3; ++row) {
+                const y = height * (0.3 + row * 0.2)
+                context.beginPath()
+                context.moveTo(width * 0.2, y)
+                context.lineTo(width * 0.8, y)
+                context.stroke()
+            }
+        }
+    }
+}

--- a/src/views/icons/MenuIcon.qml
+++ b/src/views/icons/MenuIcon.qml
@@ -1,8 +1,14 @@
 /*
  * Copyright(c) 2024 Sven Trittler
  *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+*/
 
 import QtQuick
 

--- a/src/views/icons/SearchIcon.qml
+++ b/src/views/icons/SearchIcon.qml
@@ -1,0 +1,66 @@
+/*
+ * Copyright(c) 2024 Sven Trittler
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+
+import QtQuick
+
+Item {
+    id: root
+
+    property color iconColor: "grey"
+    property real lineWidth: 1.8
+    property bool expanded: false
+
+    implicitWidth: 24
+    implicitHeight: 18
+
+    onIconColorChanged: searchCanvas.requestPaint()
+    onLineWidthChanged: searchCanvas.requestPaint()
+
+    Canvas {
+        id: searchCanvas
+        width: 17
+        height: 17
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+
+        onPaint: {
+            const context = getContext("2d")
+            const size = Math.min(width, height)
+            const radius = size * 0.25
+            const centerX = width * 0.4
+            const centerY = height * 0.4
+            const handleStart = radius * 0.74
+
+            context.clearRect(0, 0, width, height)
+            context.strokeStyle = root.iconColor
+            context.lineWidth = root.lineWidth
+            context.lineCap = "round"
+            context.lineJoin = "round"
+            context.beginPath()
+            context.arc(centerX, centerY, radius, 0, Math.PI * 2)
+            context.moveTo(centerX + handleStart, centerY + handleStart)
+            context.lineTo(width * 0.79, height * 0.79)
+            context.stroke()
+        }
+    }
+
+    ChevronIcon {
+        width: 9
+        height: 9
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        iconColor: root.iconColor
+        lineWidth: 1.7
+        rotation: root.expanded ? 180 : 0
+
+        Behavior on rotation {
+            NumberAnimation {
+                duration: 120
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+}

--- a/src/views/icons/SearchIcon.qml
+++ b/src/views/icons/SearchIcon.qml
@@ -1,8 +1,14 @@
 /*
  * Copyright(c) 2024 Sven Trittler
  *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution License
+ * v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
- */
+*/
 
 import QtQuick
 

--- a/src/views/nodes/Edge.qml
+++ b/src/views/nodes/Edge.qml
@@ -18,6 +18,7 @@ import QtQuick.Shapes
 
 import org.eclipse.cyclonedds.insight
 import "qrc:/src/views"
+import "qrc:/src/views/icons"
 
 Shape {
     id: edgeShape
@@ -79,12 +80,24 @@ Shape {
         }
     }
 
-    Label {
+    Row {
         id: uploadLabel
-        text: "↑" + (edgeShape.uploadSpeedBytes / edgeShape.currentCalc).toFixed(2) + " " + edgeShape.currentUnit
-        font.bold: true
-        color: "#419287"
+        spacing: 3
         visible: node1 && node2 && edgeShape.uploadSpeedBytes > 0.00 && edgeShape.speedEnabled
+
+        ArrowIcon {
+            width: 14
+            height: 14
+            y: (parent.height - height) / 2
+            direction: "up"
+            iconColor: "#419287"
+        }
+
+        Label {
+            text: (edgeShape.uploadSpeedBytes / edgeShape.currentCalc).toFixed(2) + " " + edgeShape.currentUnit
+            font.bold: true
+            color: "#419287"
+        }
 
         // midpoint + perpendicular offset up
         x: {
@@ -104,12 +117,24 @@ Shape {
         rotation: 0
     }
 
-    Label {
+    Row {
         id: downloadLabel
-        text:  "↓"  + (edgeShape.downloadSpeedBytes / edgeShape.currentCalc).toFixed(2) + " " + edgeShape.currentUnit
-        font.bold: true
-        color: "#2f62b9"
+        spacing: 3
         visible: node1 && node2 && edgeShape.downloadSpeedBytes > 0.00 && edgeShape.speedEnabled
+
+        ArrowIcon {
+            width: 14
+            height: 14
+            y: (parent.height - height) / 2
+            direction: "down"
+            iconColor: "#2f62b9"
+        }
+
+        Label {
+            text: (edgeShape.downloadSpeedBytes / edgeShape.currentCalc).toFixed(2) + " " + edgeShape.currentUnit
+            font.bold: true
+            color: "#2f62b9"
+        }
 
         x: {
             if (edgeShape.isVertical) {
@@ -161,5 +186,3 @@ Shape {
         edgeShape.speedEnabled = enabled;
     }
 }
-
-

--- a/src/views/statistics/StatisticsWindow.qml
+++ b/src/views/statistics/StatisticsWindow.qml
@@ -18,6 +18,7 @@ import QtQuick.Dialogs
 
 import org.eclipse.cyclonedds.insight
 import "qrc:/src/views"
+import "qrc:/src/views/icons"
 
 
 Rectangle {
@@ -172,7 +173,12 @@ Rectangle {
                         spacing: 0
 
                         Button {
-                            text: "←"
+                            ArrowIcon {
+                                anchors.centerIn: parent
+                                z: 1
+                                direction: "left"
+                                iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                            }
                             onClicked: {
                                 if (statisticsView.itemChartWidth >= 400) {
                                     statisticsView.itemChartWidth -= 50
@@ -180,13 +186,23 @@ Rectangle {
                             }
                         }
                         Button {
-                            text: "→"
+                            ArrowIcon {
+                                anchors.centerIn: parent
+                                z: 1
+                                direction: "right"
+                                iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                            }
                             onClicked: {
                                 statisticsView.itemChartWidth += 50
                             }
                         }
                         Button {
-                            text: "↑"
+                            ArrowIcon {
+                                anchors.centerIn: parent
+                                z: 1
+                                direction: "up"
+                                iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                            }
                             onClicked: {
                                 if (statisticsView.itemCellHeight >= 300) {
                                     statisticsView.itemCellHeight -= 50
@@ -194,7 +210,12 @@ Rectangle {
                             }
                         }
                         Button {
-                            text: "↓"
+                            ArrowIcon {
+                                anchors.centerIn: parent
+                                z: 1
+                                direction: "down"
+                                iconColor: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                            }
                             onClicked: {
                                 statisticsView.itemCellHeight += 50
                             }


### PR DESCRIPTION
This PR
- closes #94 
- closes #112

and implements:
- multiple data items with the same writer (see screenshot and #94)
- add description for a preset (see screenshot and #112)
- replace Unicode "icons" with real qml icons
- run cyclone-gif on startup (to indicate that current dds topics are listed)
- run cyclone-gif when clicking on the logo (because its fun)

Screenshot:
<img width="1397" height="893" alt="Screenshot 2026-06-07 at 15 41 02" src="https://github.com/user-attachments/assets/9e0e5865-2e48-43e8-835b-926987ae6961" />

@eboasson could you have a look?
