### PR TITLE
feature/reduce-macos-bundle-size

### DIFF
--- a/.azure/templates/build-insight.yml
+++ b/.azure/templates/build-insight.yml
@@ -155,10 +155,8 @@ steps:
   - bash: |
       set -e -x
       mkdir -p dist/bundle
-      cd dist
-      cp -r "CycloneDDS Insight.app" bundle && \
-      cd bundle
-      tar -czf cyclonedds-insight-${VERSION}-macos-x64.tar.gz CycloneDDS\ Insight.app
+      tar -czf "dist/bundle/cyclonedds-insight-${VERSION}-macos-x64.tar.gz" \
+          -C dist "CycloneDDS Insight.app"
     name: cyclonedds_insight_build_bundle
     displayName: Bundle MacOs App
     condition: eq(variables['Agent.OS'], 'Darwin')


### PR DESCRIPTION
This PR drastically reduces the size of the macOS artifact by preserving symlinks instead of dereferencing them via a `cp` command.

@eboasson, could you take a look?
