### PR TITLE
feature/remove-tester-data-tab-limit

### DIFF
--- a/src/models/tester_model.py
+++ b/src/models/tester_model.py
@@ -162,6 +162,11 @@ class WriterItem:
         self.dataItemNames.append(name or f"Data {len(self.dataTreeModels)}")
         self.dataItemIds.append(dataItemId or str(uuid.uuid4()))
 
+    def insertDataTreeModel(self, dataIndex, dataTreeModel, name=None, dataItemId=None):
+        self.dataTreeModels.insert(dataIndex, dataTreeModel)
+        self.dataItemNames.insert(dataIndex, name or f"Data {dataIndex + 1}")
+        self.dataItemIds.insert(dataIndex, dataItemId or str(uuid.uuid4()))
+
     def removeDataTreeModel(self, dataIndex):
         if len(self.dataTreeModels) <= 1 or dataIndex < 0 or dataIndex >= len(self.dataTreeModels):
             return "", ""
@@ -408,6 +413,32 @@ class TesterModel(QAbstractListModel):
         idx = self.index(currentIndex, 0)
         self.dataChanged.emit(idx, idx, [self.DataModelRole])
         return item.getDataTreeModelCount() - 1
+
+    @Slot(int, int, result=int)
+    def duplicateDataItem(self, currentIndex: int, dataIndex: int) -> int:
+        if currentIndex < 0 or currentIndex >= len(self.items.keys()):
+            return -1
+        mId = list(self.items.keys())[int(currentIndex)]
+        item = self.items[mId]
+        if not isinstance(item, WriterItem):
+            return -1
+
+        sourceModel = item.getDataTreeModel(dataIndex)
+        if sourceModel is None:
+            return -1
+
+        duplicateIndex = dataIndex + 1
+        duplicateModel = self._createDataTreeModel(
+            item.getTopicType(), sourceModel.toJson()["root"]
+        )
+        item.insertDataTreeModel(
+            duplicateIndex,
+            duplicateModel,
+            f"{item.getDataItemName(dataIndex)}-copy"
+        )
+        idx = self.index(currentIndex, 0)
+        self.dataChanged.emit(idx, idx, [self.DataModelRole])
+        return duplicateIndex
 
     @Slot(int, int, result=int)
     def removeDataItem(self, currentIndex: int, dataIndex: int) -> int:

--- a/src/views/TesterView.qml
+++ b/src/views/TesterView.qml
@@ -610,6 +610,67 @@ Rectangle {
             }
 
             ToolButton {
+                id: duplicateDataItemButton
+                implicitWidth: 26
+                implicitHeight: 26
+                hoverEnabled: true
+                onClicked: {
+                    const duplicateIndex = testerModel.duplicateDataItem(
+                                librariesCombobox.currentIndex, currentDataIndex)
+                    if (duplicateIndex >= 0) {
+                        currentDataIndex = duplicateIndex
+                        testerRev++
+                        refreshCurrentModels()
+                    }
+                }
+
+                Item {
+                    anchors.centerIn: parent
+                    width: 15
+                    height: 15
+                    z: 1
+
+                    Rectangle {
+                        x: 1
+                        y: 1
+                        width: 10
+                        height: 10
+                        radius: 1
+                        color: "transparent"
+                        border.width: 1.5
+                        border.color: rootWindow.isDarkMode ? "#a0a0a0" : "#707070"
+                    }
+
+                    Rectangle {
+                        x: 4
+                        y: 4
+                        width: 10
+                        height: 10
+                        radius: 1
+                        color: duplicateDataItemButton.palette.button
+                        border.width: 1.5
+                        border.color: rootWindow.isDarkMode ? "#d0d0d0" : "#505050"
+                    }
+                }
+
+                ToolTip {
+                    id: duplicateDataItemTooltip
+                    parent: duplicateDataItemButton
+                    visible: duplicateDataItemButton.hovered
+                    delay: 300
+                    text: "Duplicate selected data item"
+                    contentItem: Label {
+                        text: duplicateDataItemTooltip.text
+                    }
+                    background: Rectangle {
+                        border.color: rootWindow.isDarkMode ? Constants.darkBorderColor : Constants.lightBorderColor
+                        border.width: 1
+                        color: rootWindow.isDarkMode ? Constants.darkCardBackgroundColor : Constants.lightCardBackgroundColor
+                    }
+                }
+            }
+
+            ToolButton {
                 implicitWidth: 26
                 implicitHeight: 26
                 enabled: (testerRev, testerModel.getDataItemCount(librariesCombobox.currentIndex) > 1)

--- a/src/views/TesterView.qml
+++ b/src/views/TesterView.qml
@@ -472,7 +472,7 @@ Rectangle {
                         id: dataItemTab
                         required property int index
                         property bool selected: index === currentDataIndex
-                        width: Math.max(76, Math.min(180, tabNameLabel.implicitWidth + 24))
+                        width: Math.max(76, tabNameLabel.implicitWidth + 24)
                         height: selected ? 29 : 26
                         y: selected ? 0 : 3
                         radius: 5
@@ -504,7 +504,6 @@ Rectangle {
                             visible: !tabNameEditor.visible
                             text: (testerRev, testerModel.getDataItemName(librariesCombobox.currentIndex, index))
                             font.bold: selected
-                            elide: Text.ElideRight
                         }
 
                         TextField {


### PR DESCRIPTION
This PR removes the tab limit in the tester data tabs.
There is no need for a limit because you can scroll horizontal and its especially useful when the names are a bit longer to see the full name.
It also implements a duplicate button to duplicate a preset data tab.

@eboasson could you have a look?