### PR TITLE
feature/tester-listener-improvements

### DIFF
--- a/src/models/data_tree_model.py
+++ b/src/models/data_tree_model.py
@@ -523,10 +523,10 @@ class DataTreeModel(QAbstractItemModel):
         if index.isValid():
             item: DataTreeNode = index.internalPointer()
             parentX = item.parent()
+            row = item.row()
+            parentIndex = self.parent(index)
 
-            self.beginResetModel()
-
-            attrs, parent = self.getDotPath(item)            
+            attrs, parent = self.getDotPath(item)
             obj = parent.dataType
             for attr in attrs[:-1]:
                 if attr.isdigit():
@@ -534,15 +534,28 @@ class DataTreeModel(QAbstractItemModel):
                 else:
                     obj = getattr(obj, attr)
 
+            self.beginRemoveRows(parentIndex, row, row)
+
             if attrs[-1].isdigit():
                 del obj[int(attrs[-1])]
 
             if item.parentItem.role == DataTreeModel.IsOptionalRole:
                 setattr(obj, attrs[-1], None)
 
-            parentX.childItems.remove(item)
+            del parentX.childItems[row]
 
-            self.endResetModel()
+            self.endRemoveRows()
+
+            if parentX.childCount() > row:
+                firstChanged = self.index(row, 0, parentIndex)
+                lastChanged = self.index(parentX.childCount() - 1, 0, parentIndex)
+                self.dataChanged.emit(firstChanged, lastChanged, [
+                    DataTreeModel.DisplayHintRole,
+                    DataTreeModel.IsExpandable
+                ])
+
+            if parentIndex.isValid():
+                self.dataChanged.emit(parentIndex, parentIndex, [DataTreeModel.IsExpandable])
 
     def getDataObj(self):
         return self.rootItem.dataType

--- a/src/models/listener/listener_model.py
+++ b/src/models/listener/listener_model.py
@@ -99,15 +99,22 @@ class ListenerModel(QAbstractListModel):
             self.IsCheckedRole: b"isChecked"
         }
 
+    def _row_for_id(self, _id: str):
+        try:
+            return list(self.readers.keys()).index(_id)
+        except ValueError:
+            return -1
+
     @Slot(str)
     def deleteReader(self, _id: str):
         if _id in self.readers:
             logging.info(f"Delete reader {_id}")
-            self.beginResetModel()
-            del self.readers[_id]
             for key in self.threads:
                 self.threads[key].deleteReader(_id)
-            self.endResetModel()
+            row = self._row_for_id(_id)
+            self.beginRemoveRows(QModelIndex(), row, row)
+            del self.readers[_id]
+            self.endRemoveRows()
 
     @Slot(str)
     def startReader(self, _id: str):
@@ -115,9 +122,10 @@ class ListenerModel(QAbstractListModel):
             logging.info(f"Start reader {_id}")
             readItem = self.readers[_id]
             self.createEndpointSignal.emit(_id, readItem.domainId, readItem.topic_name, readItem.topic_type, 3, "", {}, copy.deepcopy(readItem.qos))
-            self.beginResetModel()
             self.readers[_id].stopped = False
-            self.endResetModel()
+            row = self._row_for_id(_id)
+            index = self.index(row, 0)
+            self.dataChanged.emit(index, index, [self.StoppedRole])
 
     @Slot(str)
     def stopReader(self, _id: str):
@@ -125,9 +133,10 @@ class ListenerModel(QAbstractListModel):
             logging.info(f"Stop reader {_id}")
             for key in self.threads:
                 self.threads[key].deleteReader(_id)
-            self.beginResetModel()
             self.readers[_id].stopped = True
-            self.endResetModel()
+            row = self._row_for_id(_id)
+            index = self.index(row, 0)
+            self.dataChanged.emit(index, index, [self.StoppedRole])
 
     @Slot()
     def stopAllReaders(self):
@@ -156,13 +165,27 @@ class ListenerModel(QAbstractListModel):
     def setChecked(self, _id: str, checked: bool):
         if _id in self.readers:
             logging.info(f"Set checked state of reader {_id} to {checked}")
-            self.beginResetModel()
             self.readers[_id].isChecked = checked
-            self.endResetModel()
+            row = self._row_for_id(_id)
+            index = self.index(row, 0)
+            self.dataChanged.emit(index, index, [self.IsCheckedRole])
 
-    @Slot(int, str, str, str, object)
+    @Slot(str, int, str, str, object)
     def addReader(self, id: str, domainId, topic_name, topic_type: str, qos):
         logging.info("AddReader to ListenerModel")
-        self.beginResetModel()
+        if id in self.readers:
+            self.readers[id] = ReaderData(id, domainId, topic_name, topic_type, qos, False, True)
+            row = self._row_for_id(id)
+            index = self.index(row, 0)
+            self.dataChanged.emit(index, index, [
+                self.TopicNameRole,
+                self.TopicTypeRole,
+                self.StoppedRole,
+                self.IsCheckedRole
+            ])
+            return
+
+        row = self.rowCount()
+        self.beginInsertRows(QModelIndex(), row, row)
         self.readers[id] = ReaderData(id, domainId, topic_name, topic_type, qos, False, True)
-        self.endResetModel()
+        self.endInsertRows()

--- a/src/models/listener/listener_model.py
+++ b/src/models/listener/listener_model.py
@@ -53,6 +53,7 @@ class ListenerModel(QAbstractListModel):
     IsCheckedRole = Qt.UserRole + 5
 
     createEndpointSignal = Signal(str, int, str, str, int, str, object, object)
+    allCheckedChanged = Signal()
 
     def __init__(self, threads, parent=None):
         super().__init__(parent)
@@ -105,6 +106,10 @@ class ListenerModel(QAbstractListModel):
         except ValueError:
             return -1
 
+    @Property(bool, notify=allCheckedChanged)
+    def allChecked(self):
+        return bool(self.readers) and all(reader.isChecked for reader in self.readers.values())
+
     @Slot(str)
     def deleteReader(self, _id: str):
         if _id in self.readers:
@@ -115,6 +120,7 @@ class ListenerModel(QAbstractListModel):
             self.beginRemoveRows(QModelIndex(), row, row)
             del self.readers[_id]
             self.endRemoveRows()
+            self.allCheckedChanged.emit()
 
     @Slot(str)
     def startReader(self, _id: str):
@@ -160,6 +166,7 @@ class ListenerModel(QAbstractListModel):
         self.beginResetModel()
         self.readers.clear()
         self.endResetModel()
+        self.allCheckedChanged.emit()
 
     @Slot(str, bool)
     def setChecked(self, _id: str, checked: bool):
@@ -169,6 +176,26 @@ class ListenerModel(QAbstractListModel):
             row = self._row_for_id(_id)
             index = self.index(row, 0)
             self.dataChanged.emit(index, index, [self.IsCheckedRole])
+            self.allCheckedChanged.emit()
+
+    @Slot(bool)
+    def setAllChecked(self, checked: bool):
+        logging.info(f"Set checked state of all readers to {checked}")
+        changed = False
+        for reader in self.readers.values():
+            if reader.isChecked != checked:
+                reader.isChecked = checked
+                changed = True
+
+        if changed:
+            first = self.index(0, 0)
+            last = self.index(self.rowCount() - 1, 0)
+            self.dataChanged.emit(first, last, [self.IsCheckedRole])
+            self.allCheckedChanged.emit()
+
+    @Slot(result=list)
+    def readerIds(self):
+        return list(self.readers.keys())
 
     @Slot(str, int, str, str, object)
     def addReader(self, id: str, domainId, topic_name, topic_type: str, qos):
@@ -183,9 +210,11 @@ class ListenerModel(QAbstractListModel):
                 self.StoppedRole,
                 self.IsCheckedRole
             ])
+            self.allCheckedChanged.emit()
             return
 
         row = self.rowCount()
         self.beginInsertRows(QModelIndex(), row, row)
         self.readers[id] = ReaderData(id, domainId, topic_name, topic_type, qos, False, True)
         self.endInsertRows()
+        self.allCheckedChanged.emit()

--- a/src/models/listener/receiver_proxy_model.py
+++ b/src/models/listener/receiver_proxy_model.py
@@ -32,6 +32,25 @@ class ReceiverProxyModel(QSortFilterProxyModel):
         
         self.invalidateFilter()
 
+    @Slot(list, bool)
+    def showReaderIds(self, reader_ids, show: bool):
+        changed = False
+        for reader_id in reader_ids:
+            if not reader_id:
+                continue
+
+            if show:
+                if reader_id in self._hidden_reader_ids:
+                    self._hidden_reader_ids.remove(reader_id)
+                    changed = True
+            else:
+                if reader_id not in self._hidden_reader_ids:
+                    self._hidden_reader_ids.add(reader_id)
+                    changed = True
+
+        if changed:
+            self.invalidateFilter()
+
     @Slot()
     def clearHiddenReaderIds(self):
         if self._hidden_reader_ids:

--- a/src/views/ListenerView.qml
+++ b/src/views/ListenerView.qml
@@ -92,18 +92,6 @@ Rectangle {
             spacing: 8
 
             Button {
-                text: started ? "Stop" : "Start"
-                onClicked: {
-                    started = !started
-                    if (started) {
-                        listenerModel.startAllReaders()
-                    } else {
-                        listenerModel.stopAllReaders()
-                    }
-                }
-            }
-
-            Button {
                 text: qsTrId("general.clear")
                 onClicked: receiverModel.clear()
             }
@@ -313,8 +301,41 @@ Rectangle {
                     onAccepted: listenerProxyModel.searchText = text
                 }
 
-                Button {
-                    text: "Delete All"
+                IconActionButton {
+                    icon: listenerModel.allChecked ? "deselect-all" : "select-all"
+                    tooltipText: listenerModel.allChecked
+                                 ? "Deselect all readers"
+                                 : "Select all readers"
+                    onClicked: {
+                        if (listenerModel.allChecked) {
+                            receiverProxyModel.showReaderIds(listenerModel.readerIds(), false)
+                            listenerModel.setAllChecked(false)
+                        } else {
+                            listenerModel.setAllChecked(true)
+                            receiverProxyModel.clearHiddenReaderIds()
+                        }
+                    }
+                }
+
+                IconActionButton {
+                    icon: listenerTabId.started ? "stop-all" : "play-all"
+                    tooltipText: listenerTabId.started
+                                 ? "Stop all readers"
+                                 : "Start all readers"
+                    onClicked: {
+                        listenerTabId.started = !listenerTabId.started
+                        if (listenerTabId.started) {
+                            listenerModel.startAllReaders()
+                        } else {
+                            listenerModel.stopAllReaders()
+                        }
+                    }
+                }
+
+                IconActionButton {
+                    icon: "delete-all"
+                    tooltipText: "Delete all readers"
+                    destructive: true
                     onClicked: listenerModel.deleteAllReaders()
                 }
             }

--- a/src/views/ListenerView.qml
+++ b/src/views/ListenerView.qml
@@ -113,10 +113,14 @@ Rectangle {
             }
 
             Button {
+                id: importButton
                 text: "Import"
                 onClicked: importMenu.open()
                 Menu {
                     id: importMenu
+                    x: importButton.width - width
+                    y: importButton.height + 4
+
                     MenuItem {
                         text: "Import Listener Preset"
                         onClicked: importListenerPresetDialog.open()
@@ -124,11 +128,15 @@ Rectangle {
                 }
             }
             Button {
+                id: exportButton
                 text: "Export"
                 onClicked: exportMenu.open()
 
                 Menu {
                     id: exportMenu
+                    x: exportButton.width - width
+                    y: exportButton.height + 4
+
                     MenuItem {
                         text: "Export Listener Preset"
                         onClicked: exportListenerPresetDialog.open()

--- a/src/views/Overview.qml
+++ b/src/views/Overview.qml
@@ -33,6 +33,9 @@ SplitView {
     property bool splitTester: false
     property bool splitListener: false
     property bool splitModeActive: false
+    property bool sidebarCollapsed: false
+    property int sidebarExpandedWidth: 350
+    readonly property int sidebarCollapsedWidth: 30
     readonly property int splitViewCount:
         (splitDetails ? 1 : 0)
         + (splitStatistics ? 1 : 0)
@@ -40,30 +43,106 @@ SplitView {
         + (splitListener ? 1 : 0)
     readonly property bool multiViewEnabled: splitModeActive
 
-    SplitView {
-        orientation: Qt.Vertical
+    Item {
+        id: sidebarPane
+        implicitWidth: overviewRoot.sidebarExpandedWidth
+        SplitView.minimumWidth: overviewRoot.sidebarCollapsed
+                                ? overviewRoot.sidebarCollapsedWidth
+                                : 180
+        SplitView.maximumWidth: overviewRoot.sidebarCollapsed
+                                ? overviewRoot.sidebarCollapsedWidth
+                                : 100000
+        SplitView.preferredWidth: overviewRoot.sidebarCollapsed
+                                  ? overviewRoot.sidebarCollapsedWidth
+                                  : overviewRoot.sidebarExpandedWidth
 
-        implicitWidth: 350
-        SplitView.minimumWidth: 50
-        
-        Rectangle {
-            id: domainSplit
-            color: Constants.overviewBackgroundColor(rootWindow.isDarkMode)
-
-            SplitView.minimumHeight: 50
-            SplitView.fillHeight: true
-
-            SideView {}
+        onWidthChanged: {
+            if (!overviewRoot.sidebarCollapsed && width > 180) {
+                overviewRoot.sidebarExpandedWidth = width
+            }
         }
 
         Rectangle {
-            id: datamodelSplit
+            anchors.fill: parent
             color: Constants.overviewBackgroundColor(rootWindow.isDarkMode)
+        }
 
-            SplitView.minimumHeight: 50
-            SplitView.preferredHeight: parent.height / 3
+        SplitView {
+            id: sidebarContent
+            anchors.fill: parent
+            orientation: Qt.Vertical
+            visible: !overviewRoot.sidebarCollapsed
 
-            DataModelOverview {}
+            Rectangle {
+                id: domainSplit
+                color: Constants.overviewBackgroundColor(rootWindow.isDarkMode)
+
+                SplitView.minimumHeight: 50
+                SplitView.fillHeight: true
+
+                SideView {}
+            }
+
+            Rectangle {
+                id: datamodelSplit
+                color: Constants.overviewBackgroundColor(rootWindow.isDarkMode)
+
+                SplitView.minimumHeight: 50
+                SplitView.preferredHeight: parent.height / 3
+
+                DataModelOverview {}
+            }
+        }
+
+        Rectangle {
+            id: sidebarCollapseButton
+            anchors.right: parent.right
+            anchors.rightMargin: 3
+            anchors.verticalCenter: parent.verticalCenter
+            width: 24
+            height: 42
+            radius: Constants.controlRadius
+            color: sidebarCollapseMouseArea.containsMouse
+                   ? rootWindow.isDarkMode ? "#383838" : "#e9e9e9"
+                   : Constants.cardBackgroundColor(rootWindow.isDarkMode)
+            border.width: 1
+            border.color: Constants.designBorderColor(rootWindow.isDarkMode)
+            z: 2
+
+            ArrowIcon {
+                anchors.centerIn: parent
+                width: 14
+                height: 14
+                direction: overviewRoot.sidebarCollapsed ? "right" : "left"
+                iconColor: Constants.mutedForegroundColor(rootWindow.isDarkMode)
+                lineWidth: 2
+            }
+
+            MouseArea {
+                id: sidebarCollapseMouseArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: overviewRoot.toggleSidebar()
+            }
+
+            ToolTip {
+                id: sidebarCollapseTooltip
+                parent: sidebarCollapseButton
+                visible: sidebarCollapseMouseArea.containsMouse
+                delay: 500
+                text: overviewRoot.sidebarCollapsed
+                      ? "Show sidebar"
+                      : "Hide sidebar"
+                contentItem: Label {
+                    text: sidebarCollapseTooltip.text
+                }
+                background: Rectangle {
+                    border.width: 1
+                    border.color: Constants.borderColor(rootWindow.isDarkMode)
+                    color: Constants.cardBackgroundColor(rootWindow.isDarkMode)
+                }
+            }
         }
     }
 
@@ -344,6 +423,19 @@ SplitView {
         if (childView) {
             childView.destroy()
         }    
+    }
+
+    function toggleSidebar() {
+        if (sidebarCollapsed) {
+            sidebarCollapsed = false
+            sidebarPane.SplitView.preferredWidth = sidebarExpandedWidth
+        } else {
+            if (sidebarPane.width > 180) {
+                sidebarExpandedWidth = sidebarPane.width
+            }
+            sidebarCollapsed = true
+            sidebarPane.SplitView.preferredWidth = sidebarCollapsedWidth
+        }
     }
 
     function showView(name, data) {

--- a/src/views/TesterView.qml
+++ b/src/views/TesterView.qml
@@ -962,10 +962,23 @@ Rectangle {
                         direction: expanded ? "down" : "right"
 
                         TapHandler {
-                            onSingleTapped: {
+                            function selectCurrentRow() {
                                 let index = treeView.index(row, column)
                                 treeView.selectionModel.setCurrentIndex(index, ItemSelectionModel.NoUpdate)
+                            }
+
+                            onSingleTapped: {
+                                selectCurrentRow()
                                 treeView.toggleExpanded(row)
+                            }
+
+                            onLongPressed: {
+                                selectCurrentRow()
+                                if (typeof treeView.expandRecursively === "function") {
+                                    treeView.expandRecursively(row, -1)
+                                } else {
+                                    treeView.expand(row)
+                                }
                             }
                         }
                     }

--- a/src/views/elements/IconActionButton.qml
+++ b/src/views/elements/IconActionButton.qml
@@ -70,8 +70,28 @@ Rectangle {
                 context.lineTo(4, 11.5)
                 context.closePath()
                 context.fill()
+            } else if (iconActionButton.icon === "play-all") {
+                context.beginPath()
+                context.moveTo(2.5, 3.5)
+                context.lineTo(8.5, 7)
+                context.lineTo(2.5, 10.5)
+                context.closePath()
+                context.stroke()
+
+                context.beginPath()
+                context.moveTo(5.5, 2.5)
+                context.lineTo(11.5, 7)
+                context.lineTo(5.5, 11.5)
+                context.closePath()
+                context.fill()
             } else if (iconActionButton.icon === "stop") {
                 context.fillRect(3, 3, 8, 8)
+            } else if (iconActionButton.icon === "stop-all") {
+                context.fillRect(5, 5, 6.5, 6.5)
+
+                context.beginPath()
+                context.rect(3.2, 3.2, 6.5, 6.5)
+                context.stroke()
             } else if (iconActionButton.icon === "delete") {
                 context.beginPath()
                 context.moveTo(3.5, 4.5)
@@ -92,6 +112,49 @@ Rectangle {
                 context.lineTo(6, 10)
                 context.moveTo(8, 6)
                 context.lineTo(8, 10)
+                context.stroke()
+            } else if (iconActionButton.icon === "delete-all") {
+                context.beginPath()
+                context.moveTo(1.8, 5)
+                context.lineTo(2.3, 10.5)
+                context.lineTo(6.3, 10.5)
+                context.moveTo(1.2, 4.2)
+                context.lineTo(7, 4.2)
+                context.moveTo(3.1, 3)
+                context.lineTo(5.4, 3)
+                context.stroke()
+
+                context.beginPath()
+                context.moveTo(5.5, 5)
+                context.lineTo(6.2, 12)
+                context.lineTo(11.2, 12)
+                context.lineTo(11.9, 5)
+                context.stroke()
+
+                context.beginPath()
+                context.moveTo(4.7, 4)
+                context.lineTo(12.7, 4)
+                context.moveTo(7, 2.5)
+                context.lineTo(10.5, 2.5)
+                context.moveTo(7.7, 6.8)
+                context.lineTo(7.7, 10.2)
+                context.moveTo(9.7, 6.8)
+                context.lineTo(9.7, 10.2)
+                context.stroke()
+            } else if (iconActionButton.icon === "select-all") {
+                context.strokeRect(2.5, 2.5, 9, 9)
+
+                context.beginPath()
+                context.moveTo(4.5, 7)
+                context.lineTo(6.3, 8.8)
+                context.lineTo(9.8, 5)
+                context.stroke()
+            } else if (iconActionButton.icon === "deselect-all") {
+                context.strokeRect(2.5, 2.5, 9, 9)
+
+                context.beginPath()
+                context.moveTo(4.5, 7)
+                context.lineTo(9.5, 7)
                 context.stroke()
             } else if (iconActionButton.icon === "edit") {
                 context.beginPath()


### PR DESCRIPTION
This PR implements some small usability improvements for tester and listener:

- stop listener-list to jump to beginning when interacting with listeners
- manage listeners replace text buttons with icons
- move stop all button to manage-listeners
- add select/deselect-all button to manage-listeners
- make topic/participant/datamodel sidebar collapse-able to have more space for tester/listener
- listener view import export button show menu below button not on top of it
- tester view dont collapse tree when removing array item
- tester view expand all tree elements by long press on arrow

@eboasson could you have a look?