### PR TITLE
feature/manage-listener-as-sidebar

### DIFF
--- a/src/translations/cyclonedds-insight_de.ts
+++ b/src/translations/cyclonedds-insight_de.ts
@@ -137,6 +137,12 @@
     <message id="listener.create.reader">
         <translation>Reader erstellen (Listener)</translation>
     </message>
+    <message id="listener.manage.readers">
+        <translation>Reader verwalten</translation>
+    </message>
+    <message id="listener.manage.close">
+        <translation>Reader-Verwaltung schließen</translation>
+    </message>
     <message id="tester.create.writer">
         <translation>Writer erstellen (Test-Tool)</translation>
     </message>

--- a/src/translations/cyclonedds-insight_en.ts
+++ b/src/translations/cyclonedds-insight_en.ts
@@ -132,6 +132,12 @@
     <message id="listener.create.reader">
         <translation>Create Reader (Listener)</translation>
     </message>
+    <message id="listener.manage.readers">
+        <translation>Manage Readers</translation>
+    </message>
+    <message id="listener.manage.close">
+        <translation>Close reader management</translation>
+    </message>
     <message id="tester.create.writer">
         <translation>Create Writer (Tester)</translation>
     </message>

--- a/src/views/ListenerView.qml
+++ b/src/views/ListenerView.qml
@@ -21,13 +21,13 @@ import org.eclipse.cyclonedds.insight
 import "qrc:/src/views/selection_details"
 import "qrc:/src/views/elements"
 
-
 Rectangle {
     id: listenerTabId
     anchors.fill: parent
     color: Constants.mainContentColor(rootWindow.isDarkMode)
     property bool started: true
     property bool autoScrollEnabled: true
+    property bool manageReadersVisible: false
     readonly property color surfaceColor: Constants.cardBackgroundColor(rootWindow.isDarkMode)
     readonly property color borderColor: Constants.designBorderColor(rootWindow.isDarkMode)
 
@@ -36,12 +36,12 @@ Rectangle {
         function onRowsInserted(parent, first, last) {
             // auto scroll
             if (listenerTabId.autoScrollEnabled) {
-                Qt.callLater(function() {
-                    listView.positionViewAtEnd()
-                })
+                Qt.callLater(function () {
+                    listView.positionViewAtEnd();
+                });
             }
             if (!listenerTabId.started) {
-                listenerTabId.started = true
+                listenerTabId.started = true;
             }
         }
     }
@@ -78,9 +78,7 @@ Rectangle {
             }
 
             Label {
-                text: listenerTabId.started
-                      ? qsTrId("statistic.status.running")
-                      : qsTrId("statistic.status.stopped")
+                text: listenerTabId.started ? qsTrId("statistic.status.running") : qsTrId("statistic.status.stopped")
                 font.bold: true
             }
         }
@@ -96,20 +94,22 @@ Rectangle {
                 onClicked: receiverModel.clear()
             }
 
-            Button {
-                id: comboButton
-                text: "Manage Readers"
-                onClicked: {
-                    const p = comboButton.mapToItem(Overlay.overlay, 0, comboButton.height)
-                    popup.x = p.x
-                    popup.y = p.y + 4
-                    popup.open()
-                }
-            }
-
             Item {
                 implicitHeight: 1
                 Layout.fillWidth: true
+            }
+
+            Button {
+                id: comboButton
+                text: qsTrId("listener.manage.readers")
+                checkable: true
+                checked: listenerTabId.manageReadersVisible
+                onClicked: {
+                    listenerTabId.manageReadersVisible = checked;
+                    if (!checked) {
+                        listenerProxyModel.searchText = "";
+                    }
+                }
             }
 
             Button {
@@ -149,72 +149,92 @@ Rectangle {
             }
         }
 
-        Rectangle {
-            color: listenerTabId.surfaceColor
+        SplitView {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            radius: Constants.cardRadius
-            border.width: 1
-            border.color: listenerTabId.borderColor
+            orientation: Qt.Horizontal
+            handle: Rectangle {
+                implicitWidth: 10
+                color: listenerTabId.color
+            }
 
-            ListView {
-                id: listView
-                anchors.fill: parent
-                model: receiverProxyModel
-                anchors.margins: 10
-                clip: true
+            Rectangle {
+                color: listenerTabId.surfaceColor
+                radius: Constants.cardRadius
+                border.width: 1
+                border.color: listenerTabId.borderColor
+                SplitView.fillWidth: true
+                SplitView.minimumWidth: 200
 
-                delegate: Column {
-                    width: ListView.view.width
+                ListView {
+                    id: listView
+                    anchors.fill: parent
+                    model: receiverProxyModel
+                    anchors.margins: 10
+                    clip: true
 
-                    Item {
-                        height: index > 0 ? 4 : 0
-                        width: parent.width
-                    }
-                    Rectangle {
-                        visible: index > 0
-                        width: parent.width
-                        height: 1
-                        color: Constants.separatorColor(rootWindow.isDarkMode)
-                    }
-                    Item {
-                        height: index > 0 ? 4 : 0
-                        width: parent.width
-                    }
+                    delegate: Column {
+                        width: ListView.view.width
 
-                    TextEdit {
-                        text: model.receivedMsg
-                        readOnly: true
-                        color: rootWindow.isDarkMode ? "white" : "black"
-                        wrapMode: Text.Wrap
-                        selectByMouse: true
-                        padding: 2
-                        width: parent.width
-                        onActiveFocusChanged: {
-                            if (activeFocus) {
-                                listenerTabId.autoScrollEnabled = false
+                        Item {
+                            height: index > 0 ? 4 : 0
+                            width: parent.width
+                        }
+                        Rectangle {
+                            visible: index > 0
+                            width: parent.width
+                            height: 1
+                            color: Constants.separatorColor(rootWindow.isDarkMode)
+                        }
+                        Item {
+                            height: index > 0 ? 4 : 0
+                            width: parent.width
+                        }
+
+                        TextEdit {
+                            text: model.receivedMsg
+                            readOnly: true
+                            color: rootWindow.isDarkMode ? "white" : "black"
+                            wrapMode: Text.Wrap
+                            selectByMouse: true
+                            padding: 2
+                            width: parent.width
+                            onActiveFocusChanged: {
+                                if (activeFocus) {
+                                    listenerTabId.autoScrollEnabled = false;
+                                }
                             }
                         }
                     }
+                    onMovementStarted: {
+                        listenerTabId.autoScrollEnabled = false;
+                    }
+                    ScrollBar.vertical: ScrollBar {
+                        policy: ScrollBar.AsNeeded
+                    }
                 }
-                onMovementStarted: {
-                    listenerTabId.autoScrollEnabled = false
-                }
-                ScrollBar.vertical: ScrollBar {
-                    policy: ScrollBar.AsNeeded
+
+                Button {
+                    text: "Auto Scroll"
+                    visible: !listenerTabId.autoScrollEnabled
+                    onClicked: {
+                        listenerTabId.autoScrollEnabled = true;
+                        listView.positionViewAtEnd();
+                    }
+                    anchors.right: parent.right
+                    anchors.bottom: parent.bottom
+                    anchors.margins: 10
                 }
             }
 
-            Button {
-                text: "Auto Scroll"
-                visible: !listenerTabId.autoScrollEnabled
-                onClicked: {
-                    listenerTabId.autoScrollEnabled = true
-                    listView.positionViewAtEnd()
-                }
-                anchors.right: parent.right
-                anchors.bottom: parent.bottom
-                anchors.margins: 10
+            Loader {
+                id: manageReadersPanelLoader
+                visible: listenerTabId.manageReadersVisible
+                active: visible
+                sourceComponent: manageReadersPanelComponent
+                SplitView.preferredWidth: 480
+                SplitView.minimumWidth: 320
+                SplitView.maximumWidth: Math.max(320, listenerTabId.width - 200)
             }
         }
     }
@@ -227,10 +247,10 @@ Rectangle {
         nameFilters: ["JSON files (*.json)"]
         onAccepted: {
             for (var i = 0; i < selectedFiles.length; i++) {
-                var selectedFile = selectedFiles[i]
-                console.debug("Selected file: " + selectedFile)
-                var localPath = qmlUtils.toLocalFile(selectedFile)
-                datamodelRepoModel.setQosSelectionFromFile(localPath, 3)
+                var selectedFile = selectedFiles[i];
+                console.debug("Selected file: " + selectedFile);
+                var localPath = qmlUtils.toLocalFile(selectedFile);
+                datamodelRepoModel.setQosSelectionFromFile(localPath, 3);
             }
         }
     }
@@ -245,9 +265,9 @@ Rectangle {
         selectedFile: StandardPaths.standardLocations(StandardPaths.HomeLocation)[0] + "/listener.json"
         property bool exportAll: false
         onAccepted: {
-            qmlUtils.createFileFromQUrl(selectedFile)
-            var localPath = qmlUtils.toLocalFile(selectedFile)
-            datamodelRepoModel.exportListenerPresets(localPath)
+            qmlUtils.createFileFromQUrl(selectedFile);
+            var localPath = qmlUtils.toLocalFile(selectedFile);
+            datamodelRepoModel.exportListenerPresets(localPath);
         }
     }
 
@@ -258,176 +278,175 @@ Rectangle {
         defaultSuffix: "log"
         title: "Export Sample Log"
         onAccepted: {
-            qmlUtils.createFileFromQUrl(selectedFile)
-            var localPath = qmlUtils.toLocalFile(selectedFile)
-            receiverModel.exportToFile(localPath)
+            qmlUtils.createFileFromQUrl(selectedFile);
+            var localPath = qmlUtils.toLocalFile(selectedFile);
+            receiverModel.exportToFile(localPath);
         }
     }
 
-    Popup {
-        id: popup
-        x: {
-            const p = comboButton.mapToItem(Overlay.overlay, 0, 0)
-            return p.x
-        }
+    Component {
+        id: manageReadersPanelComponent
 
-        y: {
-            const p = comboButton.mapToItem(Overlay.overlay, 0, comboButton.height)
-            return p.y + 4
-        }
-        width: parent.width * 0.4
-        modal: false
-        focus: true
-        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutside
-        parent: Overlay.overlay
-
-        background: Rectangle {
+        Rectangle {
             radius: Constants.cardRadius
             border.width: 1
-            border.color: "#999"
-            color: Constants.mainContentColor(rootWindow.isDarkMode)
-        }
+            border.color: listenerTabId.borderColor
+            color: listenerTabId.surfaceColor
 
-        onClosed: {
-            searchField.clear()
-            listenerProxyModel.searchText = ""
-        }
-
-        ColumnLayout {
-            anchors.fill: parent
-            anchors.margins: 8
-            spacing: 8
-
-            RowLayout {
-                Layout.fillWidth: true
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 8
                 spacing: 8
 
-                TextField {
-                    id: searchField
+                RowLayout {
                     Layout.fillWidth: true
-                    placeholderText: qsTrId("general.search.placeholder")
-                    onAccepted: listenerProxyModel.searchText = text
-                }
+                    spacing: 8
 
-                IconActionButton {
-                    icon: listenerModel.allChecked ? "deselect-all" : "select-all"
-                    tooltipText: listenerModel.allChecked
-                                 ? "Deselect all readers"
-                                 : "Select all readers"
-                    onClicked: {
-                        if (listenerModel.allChecked) {
-                            receiverProxyModel.showReaderIds(listenerModel.readerIds(), false)
-                            listenerModel.setAllChecked(false)
-                        } else {
-                            listenerModel.setAllChecked(true)
-                            receiverProxyModel.clearHiddenReaderIds()
+                    Label {
+                        text: qsTrId("listener.manage.readers")
+                        font.pixelSize: 16
+                        font.bold: true
+                    }
+
+                    Item {
+                        Layout.fillWidth: true
+                    }
+
+                    IconActionButton {
+                        icon: "close"
+                        tooltipText: qsTrId("listener.manage.close")
+                        onClicked: {
+                            listenerTabId.manageReadersVisible = false;
+                            listenerProxyModel.searchText = "";
                         }
                     }
                 }
 
-                IconActionButton {
-                    icon: listenerTabId.started ? "stop-all" : "play-all"
-                    tooltipText: listenerTabId.started
-                                 ? "Stop all readers"
-                                 : "Start all readers"
-                    onClicked: {
-                        listenerTabId.started = !listenerTabId.started
-                        if (listenerTabId.started) {
-                            listenerModel.startAllReaders()
-                        } else {
-                            listenerModel.stopAllReaders()
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    TextField {
+                        id: searchField
+                        Layout.fillWidth: true
+                        placeholderText: qsTrId("general.search.placeholder")
+                        onAccepted: listenerProxyModel.searchText = text
+                    }
+
+                    IconActionButton {
+                        icon: listenerModel.allChecked ? "deselect-all" : "select-all"
+                        tooltipText: listenerModel.allChecked ? "Deselect all readers" : "Select all readers"
+                        onClicked: {
+                            if (listenerModel.allChecked) {
+                                receiverProxyModel.showReaderIds(listenerModel.readerIds(), false);
+                                listenerModel.setAllChecked(false);
+                            } else {
+                                listenerModel.setAllChecked(true);
+                                receiverProxyModel.clearHiddenReaderIds();
+                            }
                         }
+                    }
+
+                    IconActionButton {
+                        icon: listenerTabId.started ? "stop-all" : "play-all"
+                        tooltipText: listenerTabId.started ? "Stop all readers" : "Start all readers"
+                        onClicked: {
+                            listenerTabId.started = !listenerTabId.started;
+                            if (listenerTabId.started) {
+                                listenerModel.startAllReaders();
+                            } else {
+                                listenerModel.stopAllReaders();
+                            }
+                        }
+                    }
+
+                    IconActionButton {
+                        icon: "delete-all"
+                        tooltipText: "Delete all readers"
+                        destructive: true
+                        onClicked: listenerModel.deleteAllReaders()
                     }
                 }
 
-                IconActionButton {
-                    icon: "delete-all"
-                    tooltipText: "Delete all readers"
-                    destructive: true
-                    onClicked: listenerModel.deleteAllReaders()
-                }
-            }
+                ListView {
+                    id: listViewSelectReaders
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    clip: true
+                    model: listenerProxyModel
 
-            ListView {
-                id: listViewSelectReaders
-                Layout.fillWidth: true
-                Layout.preferredHeight: listenerTabId.height * 0.6
-                clip: true
-                model: listenerProxyModel
+                    property var receiverProxy: receiverProxyModel
 
-                property var receiverProxy: receiverProxyModel
+                    delegate: Item {
+                        id: delegateRoot
+                        width: listViewSelectReaders.width
+                        height: 44
 
-                delegate: Item {
-                    id: delegateRoot
-                    width: listViewSelectReaders.width
-                    height: 44
+                        required property int index
+                        required property var model
 
-                    required property int index
-                    required property var model
+                        RowLayout {
+                            anchors.fill: parent
+                            anchors.leftMargin: 8
+                            anchors.rightMargin: 8
+                            spacing: 8
 
-                    RowLayout {
-                        anchors.fill: parent
-                        anchors.leftMargin: 8
-                        anchors.rightMargin: 8
-                        spacing: 8
+                            CheckBox {
+                                checked: model.isChecked
+                                onCheckedChanged: {
+                                    var readerId = model.readerId;
+                                    if (checked !== model.isChecked) {
+                                        listenerModel.setChecked(readerId, checked);
+                                        delegateRoot.ListView.view.receiverProxy.showReaderId(readerId, checked);
+                                    }
+                                }
+                            }
 
-                        CheckBox {
-                            checked: model.isChecked
-                            onCheckedChanged: {
-                                var readerId = model.readerId
-                                if (checked !== model.isChecked) {
-                                    listenerModel.setChecked(readerId, checked)
-                                    delegateRoot.ListView.view.receiverProxy.showReaderId(readerId, checked)
+                            ColumnLayout {
+                                Layout.fillWidth: true
+                                spacing: 0
+
+                                Label {
+                                    text: model.topicName
+                                    font.bold: true
+                                    elide: Text.ElideRight
+                                    Layout.fillWidth: true
+                                }
+
+                                Label {
+                                    text: model.topicType
+                                    color: "#666"
+                                    elide: Text.ElideRight
+                                    Layout.fillWidth: true
+                                }
+                            }
+
+                            IconActionButton {
+                                icon: model.stoppedReader ? "play" : "stop"
+                                tooltipText: model.stoppedReader ? "Start reader" : "Stop reader"
+                                onClicked: {
+                                    if (model.stoppedReader) {
+                                        listenerModel.startReader(model.readerId);
+                                    } else {
+                                        listenerModel.stopReader(model.readerId);
+                                    }
+                                }
+                            }
+
+                            IconActionButton {
+                                icon: "delete"
+                                tooltipText: "Delete reader"
+                                destructive: true
+                                onClicked: {
+                                    listenerModel.deleteReader(model.readerId);
                                 }
                             }
                         }
-
-                        ColumnLayout {
-                            Layout.fillWidth: true
-                            spacing: 0
-
-                            Label {
-                                text: model.topicName
-                                font.bold: true
-                                elide: Text.ElideRight
-                                Layout.fillWidth: true
-                            }
-
-                            Label {
-                                text: model.topicType
-                                color: "#666"
-                                elide: Text.ElideRight
-                                Layout.fillWidth: true
-                            }
-                        }
-
-                        IconActionButton {
-                            icon: model.stoppedReader ? "play" : "stop"
-                            tooltipText: model.stoppedReader
-                                         ? "Start reader" : "Stop reader"
-                            onClicked: {
-                                if (model.stoppedReader) {
-                                    listenerModel.startReader(model.readerId)
-                                } else {
-                                    listenerModel.stopReader(model.readerId)
-                                }
-                            }
-                        }
-
-                        IconActionButton {
-                            icon: "delete"
-                            tooltipText: "Delete reader"
-                            destructive: true
-                            onClicked: {
-                                listenerModel.deleteReader(model.readerId)
-                            }
-                        }
                     }
-                }
 
-                ScrollBar.vertical: ScrollBar { }
+                    ScrollBar.vertical: ScrollBar {}
+                }
             }
         }
     }
-
 }

--- a/src/views/elements/IconActionButton.qml
+++ b/src/views/elements/IconActionButton.qml
@@ -173,6 +173,13 @@ Rectangle {
                 context.lineTo(2.5, 12)
                 context.lineTo(4, 11.5)
                 context.stroke()
+            } else if (iconActionButton.icon === "close") {
+                context.beginPath()
+                context.moveTo(3, 3)
+                context.lineTo(11, 11)
+                context.moveTo(11, 3)
+                context.lineTo(3, 11)
+                context.stroke()
             }
         }
     }


### PR DESCRIPTION
This PR replaces the “Manage Readers” popup with a resizable sidebar.

The popup was cumbersome to use, especially with long topic names and types. It also closed whenever the user clicked elsewhere.
The new sidebar provides more space, can be resized as needed, and can remain open while working with the listener output.

@eboasson, could you please have a look?