### PR TITLE
bugfix/preserve-executable-names

### DIFF
--- a/src/dds_access/dds_utils.py
+++ b/src/dds_access/dds_utils.py
@@ -75,11 +75,15 @@ def getProperty(p: Optional[DcpsParticipant], names: List[str]):
                 break
     return propName
 
+def formatProcessName(name: str) -> str:
+    # Strip directories while preserving the full executable or application ID.
+    return Path(name.replace("\\", "/")).name
+
+def getProcessName(p: Optional[DcpsParticipant]) -> str:
+    return formatProcessName(getProperty(p, PROCESS_NAMES))
+
 def getAppName(p: Optional[DcpsParticipant]):
-    appNameWithPath = getProperty(p, PROCESS_NAMES)
-    pid = getProperty(p, PIDS)
-    appNameStem = Path(appNameWithPath.replace("\\", f"{os.path.sep}")).stem
-    return  appNameStem + ":" + pid
+    return getProcessName(p) + ":" + getProperty(p, PIDS)
 
 def looksLikeHostname(s: str) -> bool:
     if not s or len(s) > 255:
@@ -430,4 +434,3 @@ def toQos(
             pass
 
         return dpQps, topicQos, pubSubQos, qos
-

--- a/src/dds_access/dds_utils.py
+++ b/src/dds_access/dds_utils.py
@@ -77,7 +77,7 @@ def getProperty(p: Optional[DcpsParticipant], names: List[str]):
 
 def formatProcessName(name: str) -> str:
     # Strip directories while preserving the full executable or application ID.
-    return Path(name.replace("\\", "/")).name
+    return Path(name.replace("\\", os.path.sep)).name
 
 def getProcessName(p: Optional[DcpsParticipant]) -> str:
     return formatProcessName(getProperty(p, PROCESS_NAMES))

--- a/src/models/datamodel_model/datamodel_model.py
+++ b/src/models/datamodel_model/datamodel_model.py
@@ -29,7 +29,6 @@ from dds_access.datatypes.entity_type import EntityType
 from module_handler import DataModelHandler
 from utils.qml_utils import QmlUtils
 import time
-from pathlib import Path
 
 
 class DatamodelModel(QAbstractListModel):
@@ -117,9 +116,7 @@ class DatamodelModel(QAbstractListModel):
                 writer_participant_id
             )
 
-        process_name = dds_utils.getProperty(participant, dds_utils.PROCESS_NAMES)
-        if process_name != "Unknown":
-            process_name = Path(process_name.replace("\\", os.path.sep)).stem
+        process_name = dds_utils.getProcessName(participant)
         hostname = dds_utils.getHostname(participant)
         process_id = dds_utils.getProperty(participant, dds_utils.PIDS)
         addresses = dds_utils.getProperty(participant, dds_utils.ADDRESSES)

--- a/src/models/endpoint_model.py
+++ b/src/models/endpoint_model.py
@@ -15,15 +15,13 @@ from cyclonedds.builtin import DcpsEndpoint, DcpsParticipant
 from cyclonedds import core
 from cyclonedds import qos
 from loguru import logger as logging
-import os
-from pathlib import Path
 import time
 import uuid
 from typing import Optional, List
 
 from dds_access import dds_data
 from dds_access.dds_data import DataEndpoint
-from dds_access.dds_utils import getProperty, getHostname, PROCESS_NAMES, PIDS, ADDRESSES
+from dds_access.dds_utils import getProperty, getHostname, getProcessName, PIDS, ADDRESSES
 from dds_access.dds_qos import partitions_match_p
 from dds_access.datatypes.entity_type import EntityType
 
@@ -186,8 +184,7 @@ class EndpointModel(QAbstractItemModel):
         elif role == self.ProcessIdRole:
             return getProperty(p, PIDS)
         elif role == self.ProcessNameRole:
-            appname: str = getProperty(p, PROCESS_NAMES)
-            return Path(appname.replace("\\", f"{os.path.sep}")).stem
+            return getProcessName(p)
         elif role == self.AddressesRole:
             return getProperty(p, ADDRESSES)
         elif role == self.EndpointHasQosMismatch:

--- a/src/models/graph_model.py
+++ b/src/models/graph_model.py
@@ -13,7 +13,6 @@
 from PySide6.QtCore import Qt, QAbstractItemModel, Qt, Slot, Signal, QThread
 from cyclonedds.builtin import DcpsParticipant
 from loguru import logger as logging
-from pathlib import Path
 from dds_access import dds_utils
 from threading import Lock
 import uuid
@@ -179,7 +178,7 @@ class GraphModel(QAbstractItemModel):
 
         proc = psutil.Process()
         hostName = socket.gethostname()
-        self.selfName = f"{hostName}:{Path(proc.exe()).stem}:{proc.pid}"
+        self.selfName = f"{hostName}:{dds_utils.formatProcessName(proc.exe())}:{proc.pid}"
 
         self.dds_data = dds_data.DdsData()
 


### PR DESCRIPTION
Process names containing dots were truncated because the display logic removed the final component as a file extension. 

This handled Windows executable names such as app.exe, but also incorrectly shortened application IDs such as org.eclipse.cyclonedds.insight to org.eclipse.cyclonedds.

The updated logic removes only directory paths and preserves the full executable or application name, including .exe.

@eboasson could you have a look?